### PR TITLE
feat(auth): enhance JWT handling and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ LOG_LEVEL=info
 APP_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:3001
 JWT_SECRET=68ec8aa701a5e3f2029afc4ff2dfc4ba2e433b58166c9b4c73183752afdedb7b
+# Access JWT lifetime in minutes (default 15 if unset). Min 1, max 10080.
+# JWT_ACCESS_TOKEN_DURATION_MINUTES=15
 
 # Database — SSL
 DB_SSL_MODE=verify-full

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -21,3 +21,7 @@ var ErrEmailNotVerified = fmt.Errorf("email not verified")
 // En: ErrTokenNotFound is returned when a refresh token does not exist.
 // Es: ErrTokenNotFound se devuelve cuando un token de actualización no existe.
 var ErrTokenNotFound = fmt.Errorf("refresh token not found")
+
+// En: ErrJWTUsedAsRefreshToken is returned when the client sends a JWT (access token) as refresh_token.
+// Es: ErrJWTUsedAsRefreshToken se devuelve cuando el cliente envía un JWT (access token) como refresh_token.
+var ErrJWTUsedAsRefreshToken = fmt.Errorf("jwt used as refresh token")

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -81,6 +81,10 @@ func (handler *Handler) Refresh(ctx fiber.Ctx) error {
 
 	pair, err := handler.service.RefreshTokens(req.RefreshToken)
 	if err != nil {
+		if errors.Is(err, ErrJWTUsedAsRefreshToken) {
+			return runtimeError.Respond(ctx, fiber.StatusBadRequest, runtimeError.CodeRefreshTokenWrongFormat,
+				"Use refresh_token (opaque value from login), not access_token (JWT)")
+		}
 		if errors.Is(err, ErrInvalidCredentials) {
 			return runtimeError.Respond(ctx, fiber.StatusUnauthorized, runtimeError.CodeTokenInvalid, "Invalid or expired refresh token")
 		}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -270,6 +270,32 @@ func TestRefreshInvalidToken(test *testing.T) {
 	assert.Equal(test, runtimeError.CodeTokenInvalid, errResp.Error.Code)
 }
 
+// En: TestRefreshRejectsAccessTokenAsRefreshToken ensures JWT access tokens are not accepted as refresh_token.
+// Es: TestRefreshRejectsAccessTokenAsRefreshToken asegura que los JWT de acceso no se aceptan como refresh_token.
+func TestRefreshRejectsAccessTokenAsRefreshToken(test *testing.T) {
+	handler, service := SetupAuthHandlerTest(test)
+	createVerifiedTestUser(test, "Frank", "frank@example.com", "password123")
+
+	pair, err := service.Login("frank@example.com", "password123")
+	require.NoError(test, err)
+
+	app := fiber.New()
+	app.Post("/auth/refresh", handler.Refresh)
+
+	bodyStr, err := json.Marshal(map[string]string{"refresh_token": pair.AccessToken})
+	require.NoError(test, err)
+	req := httptest.NewRequest("POST", "/auth/refresh", strings.NewReader(string(bodyStr)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 0})
+	require.NoError(test, err)
+	defer resp.Body.Close()
+
+	assert.Equal(test, fiber.StatusBadRequest, resp.StatusCode)
+	errResp := DecodeErrorResponse(test, resp.Body)
+	assert.Equal(test, runtimeError.CodeRefreshTokenWrongFormat, errResp.Error.Code)
+}
+
 // En: TestRefreshTokenRotationOldTokenInvalidAfterRefresh tests the refresh token rotation with an invalid token after refresh.
 // Es: TestRefreshTokenRotationOldTokenInvalidAfterRefresh prueba el refresco de token con token inválido después de refrescar.
 func TestRefreshTokenRotationOldTokenInvalidAfterRefresh(test *testing.T) {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -17,13 +17,11 @@ import (
 	"github.com/cloudflax/api.cloudflax/internal/user"
 )
 
-// En: accessTokenDuration is the duration of the access token.
-// Es: accessTokenDuration es el tiempo de duración del token de acceso.
 const (
-	accessTokenDuration       = 15 * time.Minute
-	refreshTokenDuration      = 7 * 24 * time.Hour
-	refreshTokenBytes         = 32
-	verificationTokenDuration = 24 * time.Hour
+	defaultAccessTokenDuration = 15 * time.Minute
+	refreshTokenDuration       = 7 * 24 * time.Hour
+	refreshTokenBytes          = 32
+	verificationTokenDuration  = 24 * time.Hour
 )
 
 // En: Claims holds the JWT payload for access tokens.
@@ -57,16 +55,19 @@ type ServiceOptions struct {
 	JWTSecret            string
 	VerificationNotifier verificationnotify.Notifier
 	FrontendURL          string
+	// AccessTokenDuration is the JWT access token lifetime; zero defaults to 15 minutes.
+	AccessTokenDuration time.Duration
 }
 
 // En: Service handles the business logic of authentication.
 // Es: Service maneja la lógica de negocios de la autenticación.
 type Service struct {
-	repository           *Repository
-	userRepository       UserRepository
-	jwtSecret            []byte
-	verificationNotifier verificationnotify.Notifier
-	frontendURL          string
+	repository            *Repository
+	userRepository        UserRepository
+	jwtSecret             []byte
+	verificationNotifier  verificationnotify.Notifier
+	frontendURL           string
+	accessTokenDuration   time.Duration
 }
 
 // En: NewService creates a new authentication service.
@@ -76,12 +77,17 @@ func NewService(repository *Repository, userRepository UserRepository, opts Serv
 	if notifier == nil {
 		notifier = verificationnotify.NoopNotifier{}
 	}
+	accessDur := opts.AccessTokenDuration
+	if accessDur <= 0 {
+		accessDur = defaultAccessTokenDuration
+	}
 	return &Service{
 		repository:           repository,
 		userRepository:       userRepository,
 		jwtSecret:            []byte(opts.JWTSecret),
 		verificationNotifier: notifier,
 		frontendURL:          strings.TrimSuffix(strings.TrimSpace(opts.FrontendURL), "/"),
+		accessTokenDuration:  accessDur,
 	}
 }
 
@@ -200,6 +206,11 @@ func (service *Service) Login(email, password string) (*TokenPair, error) {
 // En: RefreshTokens validates an existing refresh token, revokes it (rotation) and emits a new token pair.
 // Es: RefreshTokens valida un token de actualización existente, lo revoca (rotación) y emite un nuevo par de tokens.
 func (service *Service) RefreshTokens(rawRefreshToken string) (*TokenPair, error) {
+	rawRefreshToken = strings.TrimSpace(rawRefreshToken)
+	if looksLikeJWT(rawRefreshToken) {
+		return nil, ErrJWTUsedAsRefreshToken
+	}
+
 	tokenHash := hashToken(rawRefreshToken)
 	stored, err := service.repository.GetByTokenHash(tokenHash)
 	if err != nil {
@@ -258,7 +269,7 @@ func (service *Service) parseAccessToken(tokenString string) (*Claims, error) {
 // En: generateTokenPair creates and stores a new access token and refresh token pair for the given user.
 // Es: generateTokenPair crea y almacena un nuevo par de tokens de acceso y actualización para el usuario dado.
 func (service *Service) generateTokenPair(u *user.User) (*TokenPair, error) {
-	expiresAt := time.Now().Add(accessTokenDuration)
+	expiresAt := time.Now().Add(service.accessTokenDuration)
 	accessToken, err := service.signAccessToken(u, expiresAt)
 	if err != nil {
 		return nil, fmt.Errorf("sign access token: %w", err)
@@ -316,4 +327,19 @@ func generateSecureToken() (string, error) {
 func hashToken(raw string) string {
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
+}
+
+// looksLikeJWT reports whether s has the typical three Base64URL segments of a JWT.
+// Refresh tokens in this API are opaque hex strings without dots.
+func looksLikeJWT(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/bootstrap/config/config.go
+++ b/internal/bootstrap/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 
 	// Verification email is sent by Lambda (async).
 	LambdaSendVerifyEmailName string
+
+	// JWTAccessTokenDuration is the signed JWT access token lifetime.
+	JWTAccessTokenDuration time.Duration
 }
 
 var (
@@ -68,6 +71,7 @@ func Load() (*Config, error) {
 		SESFromAddress:            getEnv("SES_FROM_ADDRESS", ""),
 		SESEndpointURL:            getEnv("SES_ENDPOINT_URL", ""),
 		LambdaSendVerifyEmailName: getEnv("LAMBDA_SEND_VERIFY_EMAIL_NAME", ""),
+		JWTAccessTokenDuration:    jwtAccessTokenDurationFromEnv(),
 	}
 
 	secretName := getEnv("AWS_SECRET_NAME", "")
@@ -147,6 +151,12 @@ func (c *Config) Validate() error {
 	if (c.DBSSLMode == "verify-full" || c.DBSSLMode == "verify-ca") && c.DBSSLRootCert == "" {
 		return fmt.Errorf("DB_SSL_ROOT_CERT is required when DB_SSL_MODE is %s", c.DBSSLMode)
 	}
+	if c.JWTAccessTokenDuration < time.Minute {
+		return fmt.Errorf("JWT_ACCESS_TOKEN_DURATION_MINUTES must be at least 1")
+	}
+	if c.JWTAccessTokenDuration > 7*24*time.Hour {
+		return fmt.Errorf("JWT_ACCESS_TOKEN_DURATION_MINUTES must not exceed 10080 (7 days)")
+	}
 	return nil
 }
 
@@ -185,4 +195,10 @@ func awsEndpointURL() string {
 		return v
 	}
 	return ""
+}
+
+// jwtAccessTokenDurationFromEnv reads JWT_ACCESS_TOKEN_DURATION_MINUTES (default 15).
+func jwtAccessTokenDurationFromEnv() time.Duration {
+	mins := getEnvInt("JWT_ACCESS_TOKEN_DURATION_MINUTES", 15)
+	return time.Duration(mins) * time.Minute
 }

--- a/internal/bootstrap/server/routes.go
+++ b/internal/bootstrap/server/routes.go
@@ -29,9 +29,10 @@ func Mount(app *fiber.App, cfg *config.Config) {
 	accountService := account.NewService(accountRepository, userRepository)
 
 	authService := auth.NewService(authRepository, userRepository, auth.ServiceOptions{
-		JWTSecret:            cfg.JWTSecret,
-		VerificationNotifier: verifyNotifier,
-		FrontendURL:          cfg.FrontendURL,
+		JWTSecret:             cfg.JWTSecret,
+		VerificationNotifier:  verifyNotifier,
+		FrontendURL:           cfg.FrontendURL,
+		AccessTokenDuration:   cfg.JWTAccessTokenDuration,
 	})
 	authHandler := auth.NewHandler(authService)
 	requireAuth := middleware.RequireAuth(authService)

--- a/internal/shared/runtimeerror/runtimeerror.go
+++ b/internal/shared/runtimeerror/runtimeerror.go
@@ -35,10 +35,11 @@ const (
 
 // Auth error codes.
 const (
-	CodeInvalidCredentials ErrorCode = "INVALID_CREDENTIALS"
-	CodeUnauthorized       ErrorCode = "UNAUTHORIZED"
-	CodeTokenExpired       ErrorCode = "TOKEN_EXPIRED"
-	CodeTokenInvalid       ErrorCode = "TOKEN_INVALID"
+	CodeInvalidCredentials      ErrorCode = "INVALID_CREDENTIALS"
+	CodeUnauthorized            ErrorCode = "UNAUTHORIZED"
+	CodeTokenExpired            ErrorCode = "TOKEN_EXPIRED"
+	CodeTokenInvalid            ErrorCode = "TOKEN_INVALID"
+	CodeRefreshTokenWrongFormat ErrorCode = "REFRESH_TOKEN_WRONG_FORMAT"
 )
 
 // ErrorDetail describes a single field-level validation failure.


### PR DESCRIPTION
## Summary
- Add `JWT_ACCESS_TOKEN_DURATION_MINUTES` to `.env.example` for configurable access token lifetime.
- Introduce `ErrJWTUsedAsRefreshToken` when an access JWT is used as a refresh token.
- Update Refresh handler to return a specific error for that misuse.
- Add tests ensuring access tokens are not accepted as refresh tokens.
- Extend `ServiceOptions` and app `Config` for customizable access token duration.

## Issue
Closes #1

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication token issuance/refresh paths and introduces new runtime validation/error codes; misconfiguration could change session lifetime or client refresh behavior.
> 
> **Overview**
> Adds a configurable JWT access-token lifetime via `JWT_ACCESS_TOKEN_DURATION_MINUTES` (default 15) wired from bootstrap config into `auth.ServiceOptions`, with validation enforcing 1 minute–7 day bounds.
> 
> Hardens the refresh flow to explicitly reject JWT-looking values sent as `refresh_token`, returning a new `REFRESH_TOKEN_WRONG_FORMAT` error code, and adds a handler test covering this misuse.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66fb0923b2e1ac01dbfaf40eda8662dd08b3b34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->