### PR TITLE
docs(agents): reorganize AGENTS.md as documentation hub

### DIFF
--- a/.cursor/rules/go-bilingual-comments.mdc
+++ b/.cursor/rules/go-bilingual-comments.mdc
@@ -1,0 +1,17 @@
+---
+description: Go — no En/Es on package doc; bilingual En/Es on declarations only; ≤15 words per bilingual line
+alwaysApply: true
+---
+
+No uses `// En:`/`// Es:` en doc de `package`.
+Arriba de `package`: comentario simple o nada.
+
+Usa `// En:` + `// Es:` solo en declaraciones:
+`type`, `func`, métodos, `const`/`var` de paquete (incluye grupos).
+No en sentencias internas (`if`, `for`, `return`, asignaciones).
+
+Cada línea `En/Es`: máximo 15 palabras (contadas tras `En:`/`Es:`).
+
+Ignora build tags, `//nolint`, y líneas generated.
+Identificadores, tags JSON/query y strings de API: inglés.
+Ejemplo: `internal/auth/dto.go`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,73 @@
 ## Agents — Cloudflax API (Backend)
 
-Este documento establece las directrices operativas que deben seguir los agentes de Cursor para garantizar la robustez, seguridad y escalabilidad de la API de Cloudflax.
+Este fichero es el **punto de entrada** para agentes de Cursor: prioridades operativas, checklist y enlaces al detalle. La normativa larga vive en los documentos enlazados; evita duplicar aquí lo que ya está cubierto allí.
 
-## Stack tecnológico
+---
 
-- **Lenguaje**: Go 1.25
-- **Framework**: Fiber v3
-- **ORM**: GORM (PostgreSQL)
-- **Observabilidad**: slog (Structured Logging)
+### 1. Mapa de documentación (léelo según la tarea)
 
-## Convenciones de Código y Naming
+| Necesitas… | Documento |
+|------------|-----------|
+| Naming CRUD, estructura `internal/{feature}/`, handler → service → repository, errores de dominio, formato JSON de API, tests de handler | [CONVENTIONS.md](./CONVENTIONS.md) |
+| Stack, capas, flujo de datos, middleware (logger, request ID, auth), workflow de implementación y migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| Descripción del producto, árbol del repo, entorno, `make` y variables | [README.md](./README.md) |
+| Nivel técnico esperado del agente y foco de respuestas | [SKILLS.md](./SKILLS.md) |
+| Contrato de auth para frontends (JWT, refresh, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
+| Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
+| Detalle por feature (modelo, errores HTTP, notas) | `internal/{feature}/README.md` (p. ej. [internal/auth/README.md](./internal/auth/README.md), [internal/user/README.md](./internal/user/README.md)) |
 
-- **Idioma**: El código fuente, logs y mensajes de error deben ser estrictamente en **inglés**.
-- **Naming CRUD**: Sigue el patrón `List{Resource}`, `Get{Resource}`, `Create{Resource}`, `Update{Resource}`.
-- **Funciones**: Mantén una lógica simple; máximo ~50 líneas por función y no más de 4 parámetros.
+---
 
-## Arquitectura y Datos
+### 2. Checklist antes de proponer cambios
 
-- **Estructura de Carpetas**: Implementa cada recurso en `internal/{recurso}/` con sus capas correspondientes:
-  - `model.go`: Definición de estructuras y tags de GORM.
-  - `repository.go`: Consultas directas a la base de datos.
-  - `service.go`: Lógica de negocio y validaciones.
-  - `handler.go`: Controladores de Fiber (entrada/salida).
-- **Gestión de Errores**: Usa `fmt.Errorf` con el verbo `%w` para mantener la trazabilidad. Nunca ignores un error.
-- **Migraciones**: Si modificas un modelo, registra la migración en `database.RunMigrations()` dentro de `cmd/api/main.go`.
+- Ejecuta **`make lint`** y **`make test`**; no dejes el pipeline roto.
+- Cambio de modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`). Ver flujo en [ARCHITECTURE.md](./ARCHITECTURE.md).
+- Trabajo **trazable** (feature, cambio de comportamiento, refactor relevante): issue en GitHub + rama asociada (ver § 4).
+- **Logs:** `slog` estructurado; no registrar passwords, tokens ni PII. Niveles y correlación: ver capa de middleware en [ARCHITECTURE.md](./ARCHITECTURE.md) y respuestas de error en [CONVENTIONS.md](./CONVENTIONS.md).
 
-## Seguridad operativa y herramientas
+---
 
-- **Logs**: Usa `slog`. Queda terminantemente prohibido loguear datos sensibles (passwords, tokens, PII).
-- **Makefile**: Usa `make lint` y `make test` como validación obligatoria antes de proponer cambios.
-- **Entorno**: El entorno de trabajo es `/app` dentro de un Devcontainer.
+### 3. Reglas compactas (si no abres otro doc)
 
+- **Idioma en código:** inglés (fuente, comentarios, mensajes de error y logs).
+- **Errores:** `fmt.Errorf("...: %w", err)`; no ignorar errores.
+- **Listados:** paginación por defecto en `List{Resource}`; forma de respuesta y `meta` en [CONVENTIONS.md](./CONVENTIONS.md).
+- **Secretos:** solo variables de entorno o sistemas seguros; nunca en el repositorio.
+- **HTTP:** validación en handler/service; mapa de códigos (`400` / `401` / `403` / `404` / `409` / `500`) alineado con [CONVENTIONS.md](./CONVENTIONS.md).
 
-## Handlers HTTP y respuestas
+---
 
-- **Consistencia en respuestas**: Estandariza la forma de responder errores y éxitos (status code + payload JSON con `message`, `data` opcional y/o `error`).
-- **Validación de entrada**: Valida siempre parámetros de ruta, query y body en la capa `handler` o `service` antes de llamar al repositorio.
-- **Errores HTTP**: Mapea los errores de negocio a códigos HTTP claros (`400` validación, `401`/`403` auth/autorización, `404` no encontrado, `409` conflicto, `500` errores inesperados).
+### 4. GitHub: issue, proyecto `@api.cloudflax`, rama y PR
 
-## Logging y observabilidad
+Para trabajo **trazable**, usa este flujo (no hace falta para ediciones mínimas acordadas).
 
-- **Niveles de log**: Usa `Debug` para detalle de desarrollo, `Info` para flujos exitosos importantes, `Warn` para situaciones anómalas recuperables y `Error` para fallos que requieren atención.
-- **Contexto estructurado**: Incluye siempre campos relevantes (por ejemplo `request_id`, `user_id`, `resource`, `operation`) usando `slog` con atributos estructurados.
-- **Trazabilidad**: Propaga un identificador de correlación por request (por ejemplo, `X-Request-ID`) y loguéalo en todos los puntos clave.
-- **No PII**: Nunca incluyas en logs passwords, tokens, credenciales, ni datos sensibles de usuarios.
+1. **Issue:** Crea la tarea en `cloudflax/api.cloudflax` con objetivos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con:
 
-## Pruebas
+   `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"`
 
-- **Cobertura mínima**: Cada nueva funcionalidad debe incluir tests de unidad para servicios y, cuando aplique, tests de integración para repositorios y endpoints críticos.
-- **make test**: Ejecuta `make test` antes de abrir un PR; no se deben introducir fallos en el pipeline de tests.
-- **Aislamiento**: Evita dependencias externas no deterministas en tests (red, tiempos reales, etc.); usa dobles de prueba o fixtures controlados.
+   (El nombre del project debe coincidir **exactamente** con el de GitHub.)
 
-## Acceso a datos y rendimiento
+2. **Rama:** `feature/<número-de-issue>-<slug-corto-en-kebab>` (ej. `feature/3-agents-md-hub`).
 
-- **Paginación obligatoria**: En listados (`List{Resource}`) implementa paginación por defecto para evitar lecturas masivas en memoria.
-- **Consultas eficientes**: Revisa índices y uso de `SELECT` específicos; evita `SELECT *` en consultas críticas.
-- **Transacciones**: Usa transacciones en el repositorio cuando varias operaciones deban ser atómicas.
+3. **Asociación issue ↔ rama:** Desarrolla en esa rama; en el **PR** incluye `Closes #N` o `Refs #N` en la descripción para vincular la issue.
 
-## Seguridad
+4. **Tablero:** Actualiza **Status** y demás campos del project (p. ej. *Ready* → *In review* → *Done*).
 
-- **Validación y saneamiento**: Valida y normaliza toda entrada externa antes de usarla en queries o lógica sensible.
-- **Principio de mínimo privilegio**: Diseña servicios y consultas asumiendo el menor conjunto posible de permisos y datos expuestos.
-- **Gestión de secretos**: Nunca hardcodees secretos o credenciales en el repositorio; deben provenir de variables de entorno o sistemas seguros.
+5. **Commits:** Mensajes en **inglés**; Conventional Commits cuando encaje (`feat`, `fix`, …). No reescribas historia en remoto con `--amend` salvo petición explícita.
 
-## Flujo de trabajo y PRs
+6. **`gh`:** Hacen falta scopes adecuados (`project`, `read:project`). Si falta permiso o login interactivo, el usuario debe ejecutar `gh auth refresh` (u otro paso que indique `gh`).
 
-- **Antes de abrir un PR**:
-  - Ejecuta `make lint` y `make test` y asegúrate de que pasan.
-  - Revisa que no haya logs de depuración temporales ni comentarios obsoletos.
-- **Durante la revisión**:
-  - Explica brevemente el propósito del cambio y cualquier decisión no obvia.
-  - Acepta y responde comentarios en inglés dentro del código, manteniendo la descripción funcional en español en la conversación con el usuario.
+**Rama dedicada:** Ábrela cuando aporte (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). No fuerces rama para cada microcambio si el equipo acuerda lo contrario.
 
-### GitHub: issue, proyecto `@api.cloudflax`, rama y PR (cuando aplique)
+---
 
-Para trabajo **trazable** (features, cambios de comportamiento, refactors relevantes), sigue este flujo **sin tratarlo como obligatorio para cada edición mínima**.
+### 5. Flujo de comunicación con el usuario
 
-- **¿Rama nueva?** Abre rama dedicada **solo cuando aporte** (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). Los ajustes triviales acordados pueden integrarse sin rama si el equipo lo permite; no fuerces rama por defecto.
-- **Issue**: Crea la tarea en `cloudflax/api.cloudflax` con objetivos técnicos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (el título del project debe coincidir **exactamente** con GitHub).
-- **Etiquetas y tablero**: Asigna labels del repo cuando corresponda y mantén los campos del project alineados con la realidad (**Status**, Priority, Size, Estimate, fechas): p. ej. *Ready* cuando el código está listo para PR, *In review* al abrir el PR, *Done* tras merge a `main`.
-- **Nombre de rama** (si usas rama): `feature/<número-de-issue>-<slug-corto-en-kebab>` una vez conocido el `#` de la issue (ej. `feature/1-enhance-jwt-handling-config`). Evita slugs genéricos sin número si la issue ya existe.
-- **Commits**: Mensajes en **inglés**; convención tipo Conventional Commits cuando encaje (`feat`, `fix`, etc.). La vinculación fuerte a la issue va en el **PR**: incluye `Closes #N` o `Refs #N` en la descripción. Repetir `#N` en cada commit es **opcional**; si la rama ya está en remoto, no reescribas historia con `--amend` salvo petición explícita.
-- **PR**: Crea el PR contra `main` con resumen del cambio y `Closes #N` cuando el merge deba cerrar la issue.
-- **`gh` y permisos**: Para issues y Projects hace falta token con scopes adecuados (`project`, `read:project`). Si `gh` pide ampliar permisos o login interactivo, **indícalo al usuario** para que ejecute `gh auth refresh` (u otro paso interactivo); no sustituyas tú ese login en el agente.
+- Explica los cambios en **español**, de forma concisa.
+- Indica si el cambio toca **`.env`** o requiere **migración** de base de datos.
 
-## Flujo de Comunicación
+---
 
-- Explica los cambios en español de forma concisa.
-- Informa proactivamente si los cambios afectan al archivo `.env` o requieren una migración de base de datos.
+### 6. Stack (recordatorio)
+
+Go 1.25, Fiber v3, GORM + PostgreSQL, observabilidad con **slog**. Detalle en [ARCHITECTURE.md](./ARCHITECTURE.md) y [README.md](./README.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 | Contrato de auth para frontends (JWT, refresh, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
 | Detalle por feature (modelo, errores HTTP, notas) | `internal/{feature}/README.md` (p. ej. [internal/auth/README.md](./internal/auth/README.md), [internal/user/README.md](./internal/user/README.md)) |
-| Issue, project `@api.cloudflax`, ramas y PRs | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
+| Issue, project `@api.cloudflax`, ramas, PRs y **cadencia en equipo** (cuándo preguntar, orden issue→rama, commits/PR solo si lo pides) | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 
 ---
 
@@ -23,7 +23,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 - Ejecuta **`make lint`** y **`make test`**; no dejes el pipeline roto.
 - Cambio de modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`). Ver flujo en [ARCHITECTURE.md](./ARCHITECTURE.md).
-- Trabajo **trazable** (feature, cambio de comportamiento, refactor relevante): issue en GitHub + rama asociada — [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md).
+- Trabajo **trazable:** sigue [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) **de forma eficiente y en equipo**: pregunta al inicio si se crea rama; si confirmas, **issue primero y rama después**; **no** hagas commit, push ni PR hasta petición explícita (el revisor debe poder iterar en el código contigo).
 - **Logs:** `slog` estructurado; no registrar passwords, tokens ni PII. Niveles y correlación: ver capa de middleware en [ARCHITECTURE.md](./ARCHITECTURE.md) y respuestas de error en [CONVENTIONS.md](./CONVENTIONS.md).
 
 ---
@@ -40,7 +40,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 ### 4. GitHub: issue, proyecto `@api.cloudflax`, rama y PR
 
-El flujo completo (issue, `gh`, naming de rama, PR, tablero, commits, permisos) está en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
+El detalle operativo (comandos `gh`, nombres de rama, PR, tablero) y la **cadencia colaborativa** (qué hacer solo tras confirmación, orden issue→rama, commits/PR cuando el usuario lo pida) están en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,13 @@ Abre y lee el contenido de una **referencia solo cuando aplique** a la tarea (p.
 
 | Acción | Referencia |
 |--------|------------|
-| API, errores, JSON, tests | [CONVENTIONS.md](./CONVENTIONS.md) |
-| Stack, capas, middleware, migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
 | Entorno, `make`, árbol del repo | [README.md](./README.md) |
+| Stack, capas, middleware, migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| API, errores, JSON, tests | [CONVENTIONS.md](./CONVENTIONS.md) |
+| Issues, ramas, PR, commits | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 | Nivel y foco de tus respuestas | [SKILLS.md](./SKILLS.md) |
 | Contrato auth (JWT, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
-| Una feature concreta | `internal/{feature}/README.md` |
-| Issues, ramas, PR, commits | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 
 ### Obligaciones
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 | Contrato de auth para frontends (JWT, refresh, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
 | Detalle por feature (modelo, errores HTTP, notas) | `internal/{feature}/README.md` (p. ej. [internal/auth/README.md](./internal/auth/README.md), [internal/user/README.md](./internal/user/README.md)) |
-| Issue, project `@api.cloudflax`, ramas, PRs y **cadencia en equipo** (cuándo preguntar, orden issue→rama, commits/PR solo si lo pides) | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
+| Issue, project `@api.cloudflax`, matriz de trazabilidad (issue+rama / solo issue / **solo commits** en `feature/<ID>-…` con `Refs`/`Closes #ID`), PRs y **cadencia en equipo** | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 
 ---
 
@@ -23,7 +23,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 - Ejecuta **`make lint`** y **`make test`**; no dejes el pipeline roto.
 - Cambio de modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`). Ver flujo en [ARCHITECTURE.md](./ARCHITECTURE.md).
-- Trabajo **trazable:** sigue [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) **de forma eficiente y en equipo**: pregunta al inicio si se crea rama; si confirmas, **issue primero y rama después**; **no** hagas commit, push ni PR hasta petición explícita (el revisor debe poder iterar en el código contigo).
+- Trabajo **trazable:** [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md): pregunta al inicio la **matriz** (issue+rama, solo issue, o solo commits en rama ya existente `feature/<ID>-…` vinculando `#ID` en el mensaje). Si hace falta issue nuevo: **issue primero y rama después**. **No** hagas `push` ni PR hasta petición explícita (el revisor puede iterar en el código contigo); los **commits** cuando lo pidas o encaje el escenario acordado (inglés, Conventional Commits, `Refs`/`Closes` al `#ID` de la rama si aplica).
 - **Logs:** `slog` estructurado; no registrar passwords, tokens ni PII. Niveles y correlación: ver capa de middleware en [ARCHITECTURE.md](./ARCHITECTURE.md) y respuestas de error en [CONVENTIONS.md](./CONVENTIONS.md).
 
 ---
@@ -40,7 +40,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 ### 4. GitHub: issue, proyecto `@api.cloudflax`, rama y PR
 
-El detalle operativo (comandos `gh`, nombres de rama, PR, tablero) y la **cadencia colaborativa** (qué hacer solo tras confirmación, orden issue→rama, commits/PR cuando el usuario lo pida) están en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
+El detalle operativo (comandos `gh`, nombres de rama, PR, tablero), la **matriz de inicio** (incluida la vía *solo commits* con `#ID` tomado de `feature/<ID>-…`) y la **cadencia colaborativa** (confirmación, orden issue→rama, commits/`push`/PR cuando el usuario lo pida) están en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,56 +1,35 @@
-## Agents — Cloudflax API (Backend)
+## Agents | Cloudflax - Backend
 
-Este fichero es el **punto de entrada** para agentes de Cursor: prioridades operativas, checklist y enlaces al detalle. La normativa larga vive en los documentos enlazados; evita duplicar aquí lo que ya está cubierto allí.
+Instrucciones para quien ejecuta tareas en este repo (agente). Prioriza la lista de obligaciones; la tabla enlaza el detalle.
 
----
+Abre y lee el contenido de una **referencia solo cuando aplique** a la tarea (p. ej. auth → `AUTH_INTEGRATION`, GitHub → `GITHUB_WORKFLOW`). No recorras ni cargues documentación que no necesites.
 
-### 1. Mapa de documentación (léelo según la tarea)
+### Acción → referencia
 
-| Necesitas… | Documento |
-|------------|-----------|
-| Naming CRUD, estructura `internal/{feature}/`, handler → service → repository, errores de dominio, formato JSON de API, tests de handler | [CONVENTIONS.md](./CONVENTIONS.md) |
-| Stack, capas, flujo de datos, middleware (logger, request ID, auth), workflow de implementación y migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
-| Descripción del producto, árbol del repo, entorno, `make` y variables | [README.md](./README.md) |
-| Nivel técnico esperado del agente y foco de respuestas | [SKILLS.md](./SKILLS.md) |
-| Contrato de auth para frontends (JWT, refresh, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
+| Acción | Referencia |
+|--------|------------|
+| API, errores, JSON, tests | [CONVENTIONS.md](./CONVENTIONS.md) |
+| Stack, capas, middleware, migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| Entorno, `make`, árbol del repo | [README.md](./README.md) |
+| Nivel y foco de tus respuestas | [SKILLS.md](./SKILLS.md) |
+| Contrato auth (JWT, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
-| Detalle por feature (modelo, errores HTTP, notas) | `internal/{feature}/README.md` (p. ej. [internal/auth/README.md](./internal/auth/README.md), [internal/user/README.md](./internal/user/README.md)) |
-| Issue, project `@api.cloudflax`, matriz de trazabilidad (issue+rama / solo issue / **solo commits** en `feature/<ID>-…` con `Refs`/`Closes #ID`), PRs y **cadencia en equipo** | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
+| Una feature concreta | `internal/{feature}/README.md` |
+| Issues, ramas, PR, commits | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 
----
+### Obligaciones
 
-### 2. Checklist antes de proponer cambios
+1. Ejecuta **`make lint`** y **`make test`** antes de considerar el trabajo terminado.
+2. Si tocas el modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`); el flujo está en [ARCHITECTURE.md](./ARCHITECTURE.md).
+3. GitHub: sigue [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) (matriz al inicio). No hagas `push` ni abras PR salvo petición explícita; los commits, en inglés, Conventional, con `Refs`/`Closes` cuando aplique.
+4. Usa **`slog`** estructurado; no escribas passwords, tokens ni PII en logs.
 
-- Ejecuta **`make lint`** y **`make test`**; no dejes el pipeline roto.
-- Cambio de modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`). Ver flujo en [ARCHITECTURE.md](./ARCHITECTURE.md).
-- Trabajo **trazable:** [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md): pregunta al inicio la **matriz** (issue+rama, solo issue, o solo commits en rama ya existente `feature/<ID>-…` vinculando `#ID` en el mensaje). Si hace falta issue nuevo: **issue primero y rama después**. **No** hagas `push` ni PR hasta petición explícita (el revisor puede iterar en el código contigo); los **commits** cuando lo pidas o encaje el escenario acordado (inglés, Conventional Commits, `Refs`/`Closes` al `#ID` de la rama si aplica).
-- **Logs:** `slog` estructurado; no registrar passwords, tokens ni PII. Niveles y correlación: ver capa de middleware en [ARCHITECTURE.md](./ARCHITECTURE.md) y respuestas de error en [CONVENTIONS.md](./CONVENTIONS.md).
+### Si no abres otro doc
 
----
+Mantén el código en inglés; encadena errores con `fmt.Errorf("...: %w", err)`; secretos solo vía entorno; listados paginados y códigos HTTP según [CONVENTIONS.md](./CONVENTIONS.md).
 
-### 3. Reglas compactas (si no abres otro doc)
+### Cómo respondes al humano
 
-- **Idioma en código:** inglés (fuente, comentarios, mensajes de error y logs).
-- **Errores:** `fmt.Errorf("...: %w", err)`; no ignorar errores.
-- **Listados:** paginación por defecto en `List{Resource}`; forma de respuesta y `meta` en [CONVENTIONS.md](./CONVENTIONS.md).
-- **Secretos:** solo variables de entorno o sistemas seguros; nunca en el repositorio.
-- **HTTP:** validación en handler/service; mapa de códigos (`400` / `401` / `403` / `404` / `409` / `500`) alineado con [CONVENTIONS.md](./CONVENTIONS.md).
+Redacta en **español**, de forma concisa. Menciona explícitamente si el cambio afecta **`.env`** (o configuración por entorno) o exige **migración** de base de datos.
 
----
-
-### 4. GitHub: issue, proyecto `@api.cloudflax`, rama y PR
-
-El detalle operativo (comandos `gh`, nombres de rama, PR, tablero), la **matriz de inicio** (incluida la vía *solo commits* con `#ID` tomado de `feature/<ID>-…`) y la **cadencia colaborativa** (confirmación, orden issue→rama, commits/`push`/PR cuando el usuario lo pida) están en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
-
----
-
-### 5. Flujo de comunicación con el usuario
-
-- Explica los cambios en **español**, de forma concisa.
-- Indica si el cambio toca **`.env`** o requiere **migración** de base de datos.
-
----
-
-### 6. Stack (recordatorio)
-
-Go 1.25, Fiber v3, GORM + PostgreSQL, observabilidad con **slog**. Detalle en [ARCHITECTURE.md](./ARCHITECTURE.md) y [README.md](./README.md).
+**Stack:** Go 1.25, Fiber v3, GORM, PostgreSQL, `slog` — ampliar en [ARCHITECTURE.md](./ARCHITECTURE.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 | Contrato de auth para frontends (JWT, refresh, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
 | Detalle por feature (modelo, errores HTTP, notas) | `internal/{feature}/README.md` (p. ej. [internal/auth/README.md](./internal/auth/README.md), [internal/user/README.md](./internal/user/README.md)) |
+| Issue, project `@api.cloudflax`, ramas y PRs | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
 
 ---
 
@@ -22,7 +23,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 - Ejecuta **`make lint`** y **`make test`**; no dejes el pipeline roto.
 - Cambio de modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`). Ver flujo en [ARCHITECTURE.md](./ARCHITECTURE.md).
-- Trabajo **trazable** (feature, cambio de comportamiento, refactor relevante): issue en GitHub + rama asociada (ver § 4).
+- Trabajo **trazable** (feature, cambio de comportamiento, refactor relevante): issue en GitHub + rama asociada — [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md).
 - **Logs:** `slog` estructurado; no registrar passwords, tokens ni PII. Niveles y correlación: ver capa de middleware en [ARCHITECTURE.md](./ARCHITECTURE.md) y respuestas de error en [CONVENTIONS.md](./CONVENTIONS.md).
 
 ---
@@ -39,25 +40,7 @@ Este fichero es el **punto de entrada** para agentes de Cursor: prioridades oper
 
 ### 4. GitHub: issue, proyecto `@api.cloudflax`, rama y PR
 
-Para trabajo **trazable**, usa este flujo (no hace falta para ediciones mínimas acordadas).
-
-1. **Issue:** Crea la tarea en `cloudflax/api.cloudflax` con objetivos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con:
-
-   `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"`
-
-   (El nombre del project debe coincidir **exactamente** con el de GitHub.)
-
-2. **Rama:** `feature/<número-de-issue>-<slug-corto-en-kebab>` (ej. `feature/3-agents-md-hub`).
-
-3. **Asociación issue ↔ rama:** Desarrolla en esa rama; en el **PR** incluye `Closes #N` o `Refs #N` en la descripción para vincular la issue.
-
-4. **Tablero:** Actualiza **Status** y demás campos del project (p. ej. *Ready* → *In review* → *Done*).
-
-5. **Commits:** Mensajes en **inglés**; Conventional Commits cuando encaje (`feat`, `fix`, …). No reescribas historia en remoto con `--amend` salvo petición explícita.
-
-6. **`gh`:** Hacen falta scopes adecuados (`project`, `read:project`). Si falta permiso o login interactivo, el usuario debe ejecutar `gh auth refresh` (u otro paso que indique `gh`).
-
-**Rama dedicada:** Ábrela cuando aporte (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). No fuerces rama para cada microcambio si el equipo acuerda lo contrario.
+El flujo completo (issue, `gh`, naming de rama, PR, tablero, commits, permisos) está en **[docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md)**.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Abre y lee el contenido de una **referencia solo cuando aplique** a la tarea (p.
 | Nivel y foco de tus respuestas | [SKILLS.md](./SKILLS.md) |
 | Contrato auth (JWT, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
+| Comentarios Go (sin En/Es en doc de `package`; En/Es solo en declaraciones, no en sentencias internas) | [`.cursor/rules/go-bilingual-comments.mdc`](./.cursor/rules/go-bilingual-comments.mdc) (siempre activo en Cursor) |
 
 ### Obligaciones
 
@@ -22,10 +23,11 @@ Abre y lee el contenido de una **referencia solo cuando aplique** a la tarea (p.
 2. Si tocas el modelo GORM: registra la migración en **`database.RunMigrations()`** (`cmd/api/main.go`); el flujo está en [ARCHITECTURE.md](./ARCHITECTURE.md).
 3. GitHub: sigue [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) (matriz al inicio). No hagas `push` ni abras PR salvo petición explícita; los commits, en inglés, Conventional, con `Refs`/`Closes` cuando aplique.
 4. Usa **`slog`** estructurado; no escribas passwords, tokens ni PII en logs.
+5. Siempre que crees código, documenta según [`.cursor/rules/go-bilingual-comments.mdc`](./.cursor/rules/go-bilingual-comments.mdc).
 
 ### Si no abres otro doc
 
-Mantén el código en inglés; encadena errores con `fmt.Errorf("...: %w", err)`; secretos solo vía entorno; listados paginados y códigos HTTP según [CONVENTIONS.md](./CONVENTIONS.md).
+Mantén el **código** en inglés (identificadores, mensajes de error expuestos por la API, etc.); encadena errores con `fmt.Errorf("...: %w", err)`; secretos solo vía entorno; listados paginados y códigos HTTP según [CONVENTIONS.md](./CONVENTIONS.md).
 
 ### Cómo respondes al humano
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,61 +1,37 @@
-# Architecture — Cloudflax API (Backend)
+# Architecture | Cloudflax Backend
 
-Documentación de la estructura, patrones y flujo de datos del backend.
+## Stack
+Go (feature-driven), Fiber v3, GORM + PostgreSQL; tests unitarios e integración (PostgreSQL / SQLite in-memory).
 
----
+## `internal/` (feature-driven)
+| Ruta | Contenido |
+|------|-----------|
+| `bootstrap/` | Config, servidor, arranque |
+| `{feature}/` | Por recurso (opcional según complejidad): `handler`, `service`, `repository`, `model`, `dto`, `routes`, `validator`, helpers |
+| `shared/` | `database` (conexión + migraciones), `middleware`, `pagination`, `filtering`, `errors`, `validator`, `verificationnotify` (Lambda correo verificación), utilidades |
 
-## 1. Stack Tecnológico
+Recursos simples pueden omitir capas (p. ej. solo handler + repository + model + routes).
 
-- **Lenguaje**: Go (Estructura feature-driven).
-- **Framework**: Fiber v3.
-- **ORM**: GORM con PostgreSQL.
-- **Testing**: Unitarios y de integración con PostgreSQL/SQLite.
+## Capas
+Flujo: **Middleware → Handler → Service → Repository → DB**.
 
----
+| Capa | Rol | No hace |
+|------|-----|---------|
+| Handler | HTTP Fiber: parseo requests, respuestas | Lógica de negocio, acceso directo a DB |
+| Service | Negocio y orquestación | Depender de HTTP/Fiber ni códigos de estado |
+| Repository | Acceso datos (GORM) | Respuestas HTTP |
 
-## 2. Estructura de Directorios (Feature-driven)
+Validación: DTOs y checks **antes** del Service.
 
-Cada funcionalidad vive en su propia carpeta dentro de `internal/`:
+## Errores y transporte
+Service/Repository devuelven errores de dominio (p. ej. `ErrNotFound`, `ErrDuplicateEmail`). El Handler los mapea a HTTP + JSON. Solo el Handler conoce transporte; Service/Repository sin Fiber ni respuestas HTTP.
 
-- **`internal/bootstrap/`**: Configuración, servidor y arranque de la app.
-- **`internal/{feature}/`**: Puede contener `handler.go`, `service.go`, `repository.go`, `model.go`, `dto.go`, `routes.go` y opcionalmente `validator.go` u otros helpers específicos del recurso.
-- **`internal/shared/`**: Código común: `database` (conexión y migraciones), `middleware`, `pagination`, `filtering`, `errors`, `validator`, `verificationnotify` (invocación Lambda para correo de verificación) y otras utilidades compartidas.
+## Middleware (orden)
+`Logger → Request ID → Recovery → CORS → Auth (JWT)`  
+Logger: método, path, status, duración. Request ID: `X-Request-ID` para tracing. Recovery: `panic` → 500 controlado. CORS: frontend autorizado. Auth: JWT en rutas protegidas.
 
-No todos los features requieren todos estos archivos; un recurso simple puede usar solo `handler.go`, `repository.go`, `model.go` y `routes.go`.
-
----
-
-## 3. Patrones y Capas del Sistema
-
-- **Flujo de Datos**: `Request → Middleware → Handler → Service → Repository → DB`.
-- **Responsabilidades**:
-  - **Handler**: Solo HTTP (Fiber); parseo de requests y formateo de respuestas.
-  - **Service**: Lógica de negocio y orquestación; independiente de HTTP.
-  - **Repository**: Abstracción de acceso a datos (GORM).
-- **Validación**: Uso de DTOs y lógica de validación previa al Service.
-- **Reglas de dependencia entre capas**:
-  - **Handler**: No debe contener lógica de negocio ni acceder directamente a la base de datos; siempre delega en el Service.
-  - **Service**: No debe depender de HTTP (ni Fiber ni códigos de estado); trabaja con modelos de dominio y errores de dominio.
-  - **Repository**: No debe construir respuestas HTTP; solo se encarga del acceso a datos y de devolver errores de DB o de dominio.
-
----
-
-## 4. Manejo de Errores y Seguridad
-
-- **Errores**: Service/Repository devuelven errores de dominio (por ejemplo `ErrNotFound`, `ErrDuplicateEmail`); el Handler captura estos errores, los mapea a códigos HTTP coherentes y formatea la respuesta JSON.
-- **Restricción**: Ni Service ni Repository deben crear respuestas HTTP ni depender de Fiber; solo el Handler conoce detalles de transporte.
-- **Middleware Stack**: Logger → Request ID → Recovery → CORS → Auth (JWT).
-  - **Logger**: Registra método, path, status y duración de cada request.
-  - **Request ID**: Asigna y propaga un identificador (`X-Request-ID`) para facilitar el tracing entre logs.
-  - **Recovery**: Captura `panic` y evita la caída del servidor, devolviendo un error 500 controlado.
-  - **CORS**: Configura los encabezados para permitir el consumo desde el frontend autorizado.
-  - **Auth**: Valida JWT y restringe el acceso a rutas protegidas según la configuración de autorización.
-
----
-
-## 5. Workflow del Desarrollador
-
-1. **Implementar**: Seguir el flujo de capas definido y registrar rutas en `bootstrap/server/routes.go`.
-2. **Migrar**: Registrar cambios de modelos en `database.RunMigrations()`.
-3. **Validar**: Ejecución obligatoria de `make lint` y `make test`.
-4. **Testear**: Añadir tests unitarios por capa (Handler, Service, Repository) y tests de integración con base de datos (PostgreSQL o SQLite in-memory), ubicando los archivos `*_test.go` junto al código del feature.
+## Workflow
+1. Implementar capas; rutas en `internal/bootstrap/server/routes.go`.
+2. Cambios de modelo GORM: registrar en `database.RunMigrations()` (`cmd/api/main.go`).
+3. Antes de cerrar: `make lint` y `make test`.
+4. Tests: `*_test.go` junto al feature; unitarios por capa + integración con DB.

--- a/AUTH_INTEGRATION.md
+++ b/AUTH_INTEGRATION.md
@@ -1,4 +1,4 @@
-# Auth Integration — Cloudflax API
+# Auth Integration | Cloudflax - Backend
 
 Documento de referencia para integrar autenticación entre el frontend Next.js y este backend Go/Fiber.
 
@@ -14,15 +14,100 @@ Documento de referencia para integrar autenticación entre el frontend Next.js y
 El refresh token se almacena **hasheado (SHA-256)** en la tabla `refresh_tokens` de PostgreSQL.
 El access token **nunca** se persiste en base de datos.
 
+**Verificación de email:** `POST /auth/login` y `POST /auth/refresh` solo tienen éxito si el usuario tiene el email verificado. Si no, responden `403` con `EMAIL_VERIFICATION_REQUIRED`.
+
 ---
 
 ## Endpoints
 
 ### Base URL
 
+URL base de **esta API** (no la del frontend Next.js), p. ej. según `PORT` / `APP_URL` en el entorno. En desarrollo suele coincidir con el valor de `.env.example` (p. ej. `http://localhost:3000` si `PORT=3000`).
+
+---
+
+### POST `/auth/register`
+
+Crea usuario con credenciales email/contraseña y envía (si está configurado) el correo de verificación. No devuelve tokens.
+
+**Request:**
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{
+  "name": "Ada Lovelace",
+  "email": "user@example.com",
+  "password": "password123"
+}
 ```
-http://localhost:3000
+
+**Response 201 Created:**
+
+```json
+{
+  "data": { "id": "…", "name": "…", "email": "…" },
+  "meta": { "email_verification_required": true }
+}
 ```
+
+**Errores posibles:**
+
+| Status | `error.code` | Causa |
+|--------|-------------|-------|
+| 400 | `INVALID_REQUEST_BODY` | Body no es JSON válido |
+| 409 | `EMAIL_ALREADY_EXISTS` | Email ya registrado |
+| 422 | `VALIDATION_ERROR` | Validación de campos |
+
+---
+
+### GET `/auth/verify-email`
+
+Confirma el email con el token del enlace (query). El frontend puede redirigir a esta URL con `token` en la query.
+
+**Request:**
+
+```http
+GET /auth/verify-email?token=<uuid>
+```
+
+**Response 200 OK:**
+
+```json
+{ "message": "Email verified successfully" }
+```
+
+**Errores posibles:**
+
+| Status | `error.code` | Causa |
+|--------|-------------|-------|
+| 400 | `INVALID_REQUEST_BODY` / `VALIDATION_ERROR` | Query inválida |
+| 422 | `INVALID_VERIFICATION_TOKEN` | Token inválido o expirado |
+
+---
+
+### POST `/auth/resend-verification`
+
+Solicita un nuevo correo de verificación. Por diseño no revela si el email existe (`200` en ambos casos cuando el flujo es correcto).
+
+**Request:**
+
+```json
+{ "email": "user@example.com" }
+```
+
+**Response 200 OK:**
+
+```json
+{ "message": "If the email exists, a verification link has been sent" }
+```
+
+**Errores posibles:**
+
+| Status | `error.code` | Causa |
+|--------|-------------|-------|
+| 409 | `EMAIL_ALREADY_VERIFIED` | El email ya estaba verificado |
 
 ---
 
@@ -60,7 +145,8 @@ Content-Type: application/json
 |--------|-------------|-------|
 | 400 | `INVALID_REQUEST_BODY` | Body no es JSON válido |
 | 401 | `INVALID_CREDENTIALS` | Email o password incorrectos |
-| 422 | `VALIDATION_ERROR` | Email inválido o password < 8 chars |
+| 403 | `EMAIL_VERIFICATION_REQUIRED` | Cuenta sin email verificado |
+| 422 | `VALIDATION_ERROR` | Email inválido o password con menos de 8 caracteres |
 
 ---
 
@@ -96,7 +182,9 @@ Content-Type: application/json
 | Status | `error.code` | Causa |
 |--------|-------------|-------|
 | 400 | `INVALID_REQUEST_BODY` | Body no es JSON válido |
-| 401 | `TOKEN_INVALID` | Token inválido, ya usado o expirado |
+| 400 | `REFRESH_TOKEN_WRONG_FORMAT` | Se envió el JWT de acceso en lugar del refresh opaco |
+| 401 | `TOKEN_INVALID` | Refresh inválido, ya usado o expirado |
+| 403 | `EMAIL_VERIFICATION_REQUIRED` | Usuario sin email verificado |
 
 ---
 
@@ -117,24 +205,38 @@ Authorization: Bearer <access_token>
 
 | Status | `error.code` | Causa |
 |--------|-------------|-------|
-| 401 | `UNAUTHORIZED` | Access token ausente o inválido |
-| 401 | `TOKEN_INVALID` | Access token malformado o expirado |
+| 401 | `UNAUTHORIZED` | Sin header `Authorization` o formato distinto de `Bearer` |
+| 401 | `TOKEN_INVALID` | JWT ausente en el sentido correcto, malformado, firma inválida o expirado |
+
+---
+
+### POST `/auth/dev/verify-email-token` (solo no producción)
+
+Si `APP_ENV` ≠ `production`, el backend expone este helper de desarrollo: devuelve un token de verificación para un email (también regenera el token vía la misma lógica que resend). **No usar en producción.**
 
 ---
 
 ## Rutas protegidas
 
-Todas las rutas bajo `/users` requieren el header `Authorization: Bearer <access_token>`.
+Requieren `Authorization: Bearer <access_token>` (middleware JWT). Sin token válido: `401` con `UNAUTHORIZED` o `TOKEN_INVALID`.
+
+**Usuarios (perfil del usuario autenticado):**
 
 ```http
-GET    /users
-GET    /users/:id
-POST   /users
-PUT    /users/:id
-DELETE /users/:id
+GET    /users/me
+GET    /users/me/accounts
+PUT    /users/me
+DELETE /users/me
 ```
 
-Sin el header o con token inválido el backend responde `401 UNAUTHORIZED`.
+**Cuentas:**
+
+```http
+POST   /accounts
+POST   /accounts/active
+```
+
+**Facturas:** prefijo `/invoices` con autenticación **y** pertenencia a la cuenta activa (middleware adicional). Ver [ARCHITECTURE.md](./ARCHITECTURE.md) / código de `invoice` para el detalle.
 
 ---
 
@@ -182,7 +284,7 @@ El payload del JWT contiene:
 | `email` | Email del usuario |
 | `sub` | Igual a `user_id` (estándar JWT) |
 | `iat` | Timestamp de emisión |
-| `exp` | Timestamp de expiración (15 min) |
+| `exp` | Timestamp de expiración (por defecto 15 min; configurable con `JWT_ACCESS_TOKEN_DURATION_MINUTES`) |
 
 Algoritmo: **HS256**
 
@@ -193,8 +295,12 @@ Algoritmo: **HS256**
 ```
 [Next.js]                          [Fiber API]
 
+0. Registro y verificación (primera vez)
+   POST /auth/register ───────────► Crea usuario, envía email (Lambda si está configurado)
+   Usuario abre enlace ───────────► GET /auth/verify-email?token=...
+
 1. Login
-   POST /auth/login ──────────────► Valida credenciales
+   POST /auth/login ──────────────► Valida credenciales y email verificado
                     ◄────────────── { access_token, refresh_token }
 
 2. Guardar tokens
@@ -298,13 +404,17 @@ export async function POST() {
 | Variable | Descripción | Ejemplo |
 |----------|-------------|---------|
 | `JWT_SECRET` | Clave de firma del JWT. Mínimo 32 chars aleatorios. | `openssl rand -hex 32` |
+| `FRONTEND_URL` | Origen del frontend: CORS (`AllowOrigins`) y enlaces `.../auth/verify-email?token=` en el correo. | `http://localhost:3001` |
+| `JWT_ACCESS_TOKEN_DURATION_MINUTES` | Duración del access token (minutos). Por defecto `15`. | `15` |
+| `LAMBDA_SEND_VERIFY_EMAIL_NAME` | Nombre de la función Lambda que envía el email de verificación; vacío → no se envía correo (notifier noop). | — |
+| `APP_ENV` | Si es `production`, se oculta `POST /auth/dev/verify-email-token`. | `development` |
 
 ### Frontend (Next.js)
 
 | Variable | Descripción | Ejemplo |
 |----------|-------------|---------|
-| `NEXT_PUBLIC_API_URL` | URL base del backend (para llamadas del cliente) | `http://localhost:3000` |
-| `API_URL` | URL base del backend (para llamadas server-side) | `http://localhost:3000` |
+| `NEXT_PUBLIC_API_URL` | URL base de la **API** (llamadas desde el cliente) | Debe coincidir con el host/puerto del backend |
+| `API_URL` | URL base de la **API** (llamadas server-side / Route Handlers) | Mismo criterio |
 
 ---
 
@@ -313,45 +423,30 @@ export async function POST() {
 | `error.code` | Status | Descripción |
 |---|---|---|
 | `INVALID_CREDENTIALS` | 401 | Email o password incorrecto en login |
-| `UNAUTHORIZED` | 401 | Endpoint protegido sin token |
-| `TOKEN_INVALID` | 401 | Token malformado, firmado con otro secret, o ya revocado |
-| `TOKEN_EXPIRED` | 401 | Access token expirado (también devuelve `TOKEN_INVALID`) |
+| `EMAIL_VERIFICATION_REQUIRED` | 403 | Login o refresh con email aún no verificado |
+| `UNAUTHORIZED` | 401 | Endpoint protegido sin `Authorization` o sin esquema `Bearer` |
+| `TOKEN_INVALID` | 401 | JWT de acceso malformado, firma incorrecta o expirado; también refresh inválido/revocado en `/auth/refresh` |
+| `REFRESH_TOKEN_WRONG_FORMAT` | 400 | Se envió un JWT como `refresh_token` en lugar del token opaco |
+| `TOKEN_EXPIRED` | — | Definido en la API; el middleware de acceso actual devuelve `TOKEN_INVALID` cuando el JWT expira |
 
 ---
 
 ## CORS
 
-El backend debe tener CORS configurado para aceptar requests desde el origen del frontend. Configurar en `internal/bootstrap/app/app.go` con el middleware de Fiber:
-
-```go
-import "github.com/gofiber/fiber/v3/middleware/cors"
-
-app.Use(cors.New(cors.Config{
-    AllowOrigins:     []string{"http://localhost:3001"}, // origen del frontend
-    AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
-    AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-    AllowCredentials: true, // necesario para cookies
-}))
-```
+El origen permitido se toma de **`FRONTEND_URL`** y se aplica en el arranque vía `middleware.CORS` en `internal/bootstrap/app/app.go` (implementación en `internal/shared/middleware/cors.go`): un solo origen explícito, métodos GET/POST/PUT/PATCH/DELETE/OPTIONS, headers `Origin`, `Content-Type`, `Accept`, `Authorization`, `X-Requested-With`. Si `FRONTEND_URL` está vacío, no se permite ningún origen (fail-closed).
 
 ---
 
 ## Checklist de integración
 
 ### Backend (completado)
-- [x] `POST /auth/login` — devuelve `access_token` + `refresh_token`
-- [x] `POST /auth/refresh` — rota el refresh token
+- [x] `POST /auth/register` — alta y flujo de verificación por email
+- [x] `GET /auth/verify-email` — confirma email con token en query
+- [x] `POST /auth/resend-verification` — reenvío de correo de verificación
+- [x] `POST /auth/login` — devuelve `access_token` + `refresh_token` (requiere email verificado)
+- [x] `POST /auth/refresh` — rota el refresh token (requiere email verificado)
 - [x] `POST /auth/logout` — revoca todos los refresh tokens del usuario
-- [x] Middleware JWT — protege rutas `/users`
+- [x] Middleware JWT — protege rutas de usuario, cuenta e invoice según el router
 - [x] Refresh token rotation — el token anterior se invalida al renovar
 - [x] Refresh tokens en DB — tabla `refresh_tokens` con hash SHA-256
-
-### Frontend (pendiente)
-- [ ] Función de login que llame a `POST /auth/login`
-- [ ] Guardar `access_token` en memoria (context/store)
-- [ ] Guardar `refresh_token` como `httpOnly` cookie (vía Route Handler)
-- [ ] Interceptor HTTP que adjunte el `Authorization: Bearer` header
-- [ ] Lógica de refresh automático cuando el server devuelve `401`
-- [ ] Función de logout que llame a `POST /auth/logout` y limpie el estado
-- [ ] Rutas protegidas en Next.js (middleware `middleware.ts` con verificación de token)
-- [ ] Configurar CORS en el backend para el origen del frontend
+- [x] CORS — origen desde `FRONTEND_URL`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,142 +1,83 @@
-# Convenciones de código — Cloudflax API
+## Conventions | Cloudflax - Backend
 
-Reglas para mantener consistencia. En este archivo van:
+Naming · carpetas · errores/HTTP · handler/service/repository · DTOs · tests · estilo · docs de módulo · JSON · status.
 
-- **Naming** — Cómo nombrar funciones, variables, archivos y recursos.
-- **Estructura de carpetas** — Organización, archivos estándar por módulo y registro en bootstrap.
-- **Errores de dominio** — Sentinel errors por módulo y mapeo a respuestas HTTP.
-- **Handler, Repository, Service** — Flujo del handler, patrones de repository/service, DTOs y constructores.
-- **Tests** — Setup de handler tests, decodificación de errores y casos a cubrir.
-- **Estilo de código** — Formato, imports, comentarios y buenas prácticas de sintaxis.
-- **Documentación de módulos** — Comentario de paquete y README por feature.
-- **Formato de API** — Respuestas JSON y códigos de estado por operación.
+## CRUD naming
 
----
+Patrón global: `{Action}{Resource}`. **Resource** singular (`User`, `Order`). **Action:** `List`, `Get`, `Create`, `Update`, `Delete` → ej. `ListUser`, `GetUser`, … Aplica en `handler.go`, `service.go`, `repository.go` del feature.
 
-## Nombres CRUD
+## Carpetas y archivos
 
-**Todas las acciones CRUD usan el mismo patrón en todos los features y en todas las capas:**
+- **Feature:** `internal/{recurso}/` — singular, lowercase (`user`, `product`).
+- **Shared:** `internal/shared/{módulo}/`.
+- **Archivos:** singular, lowercase, sufijo por rol.
 
-```
-{Action}{Resource}
-```
-
-- **Resource** siempre en singular: `User`, `Country`, `Order`
-- **Action** de CRUD: `List`, `Get`, `Create`, `Update`, `Delete`
-
-| Acción | Ejemplo User | Ejemplo Country | Ejemplo Order |
-|--------|--------------|-----------------|---------------|
-| Listar | `ListUser` | `ListCountry` | `ListOrder` |
-| Obtener uno | `GetUser` | `GetCountry` | `GetOrder` |
-| Crear | `CreateUser` | `CreateCountry` | `CreateOrder` |
-| Actualizar | `UpdateUser` | `UpdateCountry` | `UpdateOrder` |
-| Eliminar | `DeleteUser` | `DeleteCountry` | `DeleteOrder` |
-
-**Aplica en:** `handler.go`, `service.go`, `repository.go` y cualquier archivo del feature.
-
----
-
-## Estructura de carpetas
-
-- **Features:** `internal/{recurso}/` — nombre en singular, lowercase (ej: `user`, `product`).
-- **Shared:** `internal/shared/{módulo}/` — código reutilizable entre features.
-- **Archivos:** Nombres en singular, lowercase, con sufijo por tipo (`handler.go`, `service.go`, `repository.go`).
-
-### Archivos estándar por módulo
-
-Cada módulo en `internal/{recurso}/` debe incluir al menos los archivos que use según responsabilidad:
-
-| Archivo | Uso |
+| Archivo | Rol |
 |---------|-----|
-| `model.go` | Modelo de dominio (GORM), tabla, métodos del modelo |
-| `repository.go` | Acceso a datos: `NewRepository(db)`, Get/Create/Update/Delete |
-| `service.go` | Lógica de negocio: `NewService(repository)`, mismos nombres CRUD que handler |
-| `handler.go` | HTTP: bind, validación, llamada al service, respuesta con `runtimeerror` |
-| `routes.go` | Función `Routes(router, handler, authMiddleware)` que monta los endpoints |
-| `dto.go` | Request/Response DTOs (ej. `CreateUserRequest`, `UpdateMeRequest`) con tags `json` y `validate` |
-| `errors.go` | Errores sentinel del dominio (ej. `ErrNotFound`, `ErrDuplicateEmail`) para que service/repository los devuelvan y el handler los mapee a códigos HTTP |
+| `model.go` | Dominio GORM, tabla |
+| `repository.go` | `NewRepository(db)`; CRUD; sentinels del paquete |
+| `service.go` | `NewService(repo)`; mismos nombres CRUD que handler |
+| `handler.go` | Bind, validate, service, `runtimeerror` |
+| `routes.go` | `Routes(router, handler, authMiddleware)` |
+| `dto.go` | `CreateXRequest`, `UpdateXRequest`; tags `json`, `validate` |
+| `errors.go` | `var ErrX = fmt.Errorf(...)` para repo/service; handler mapea a HTTP |
 
-Tests: `model_test.go` cuando el modelo tenga lógica a probar; `handler_test.go` con casos de éxito y de error. Opcionalmente tests de service o repository si la lógica lo justifica.
+Tests: `model_test.go` si hay lógica; `handler_test.go` éxito + errores. Service/repo tests si aplica.
 
-Registro del módulo: en `internal/bootstrap/server/routes.go` crear repository → service (con opciones si aplica) → handler y llamar `{recurso}.Routes(app, handler, authMiddleware)`.
+**Bootstrap:** `internal/bootstrap/server/routes.go` — repo → service (opciones) → handler → `{recurso}.Routes(app, handler, authMiddleware)`.
 
----
+## Errores y HTTP
 
-## Errores de dominio y mapeo HTTP
+- **Sentinels** en `errors.go`; repo/service los devuelven (no GORM crudo).
+- **Repo:** `gorm.ErrRecordNotFound` → `ErrNotFound`; resto `fmt.Errorf("op: %w", err)`.
+- **Handler:** `errors.Is` / `errors.As`; `runtimeerror.Respond` / `RespondWithDetails`. Validación: helper tipo `toErrorDetails(validator.ValidationErrors)` → `[]runtimeError.ErrorDetail`.
+- **Códigos de recurso** en `internal/shared/runtimeerror/runtimeerror.go` (ej. `CodeUserNotFound`). Inesperados: `slog` + `CodeInternalServerError`.
 
-- **Por módulo:** Definir en `errors.go` errores sentinel con `var ErrX = fmt.Errorf("...")` (ej. `ErrNotFound`, `ErrDuplicateEmail`). El **repository** y el **service** devuelven estos errores.
-- **Handler:** Mapear con `errors.Is(err, ErrNotFound)` (o `errors.As` para validación) y responder con `runtimeerror.Respond` / `runtimeerror.RespondWithDetails` usando los códigos definidos en `internal/shared/runtimeerror/runtimeerror.go`. Para validación, usar un helper privado tipo `toErrorDetails(validator.ValidationErrors)` que devuelva `[]runtimeError.ErrorDetail`.
-- **Códigos por recurso:** Los códigos específicos del recurso (ej. `CodeUserNotFound`, `CodeEmailAlreadyExists`) se definen en el paquete `runtimeerror`; el handler los usa al responder. Errores inesperados se loguean con `slog` y se responde con `CodeInternalServerError`.
+## Handler (orden)
 
----
+1. Auth si aplica (`requestctx.UserOnly`).
+2. `ctx.Bind().Body(&req)`.
+3. `validator.Validate(req)` → `RespondWithDetails` si hay detalles por campo.
+4. Llamar service.
+5. Mapear error → status/código.
+6. Éxito: `ctx.JSON(fiber.Map{"data": ...})` o `201` / `204` según operación.
 
-## Flujo del handler
+## Service
 
-En cada endpoint: (1) extraer contexto de auth si aplica (`requestctx.UserOnly`), (2) bind del body con `ctx.Bind().Body(&req)`, (3) validar con `validator.Validate(req)` y en caso de error usar `RespondWithDetails` si hay detalles por campo, (4) llamar al service, (5) según el error devuelto (`errors.Is`/`errors.As`) responder con el status y código adecuados, (6) en éxito devolver `ctx.JSON(fiber.Map{"data": ...})` o `ctx.Status(201).JSON(...)` / `204` según la operación.
-
----
-
-## Repository y Service
-
-- **Repository:** Traducir `gorm.ErrRecordNotFound` a los errores del paquete (ej. `ErrNotFound`). Envolver demás errores con `fmt.Errorf("operación: %w", err)`. No devolver errores de GORM crudos al service.
-- **Service:** Validar identificadores (ej. UUID con `uuid.Parse`) antes de llamar al repository; si el formato es inválido, devolver el mismo error que “no encontrado” (ej. `ErrNotFound`) para no revelar información. Dependencias externas (ej. revocador de tokens) inyectadas por **interfaz** y opcionales: comprobar `if service.dependency != nil` antes de usarlas; se pueden exponer con métodos tipo `WithTokenRevoker(tr) *Service` para mantener el constructor simple.
-
----
+- Validar IDs (ej. `uuid.Parse`); inválido → mismo error que no encontrado (`ErrNotFound`).
+- Dependencias externas por **interfaz**; opcionales: `if dep != nil`; builder `WithTokenRevoker(tr) *Service` si hace falta.
 
 ## DTOs y constructores
 
-- **DTOs:** Nombres `Create{Resource}Request`, `Update{Resource}Request` (o `UpdateMeRequest` cuando aplique). Usar tags `json` y `validate`; en updates usar punteros para campos opcionales.
-- **Constructores:** `NewRepository(db *gorm.DB)`, `NewService(repository *Repository)`, `NewHandler(service *Service)`. Dependencias opcionales del service mediante métodos que devuelven `*Service` (builder style) para no complicar la firma del constructor.
-
----
+- DTOs: `Create{Resource}Request`, `Update{Resource}Request` (o `UpdateMeRequest`). Updates: punteros para opcionales.
+- `NewRepository(db)`, `NewService(repo)`, `NewHandler(service)`. Opcionales vía métodos `*Service`, no firma gigante.
 
 ## Tests de handler
 
-- **Parámetro de test:** En todas las funciones de test y helpers de test usar siempre `test *testing.T` (no `t *testing.T`). Ejemplo: `func SetupUserHandlerTest(test *testing.T) *Handler`, `func TestGetMe(test *testing.T)`.
-- **Setup:** Un helper `Setup{Resource}HandlerTest(test *testing.T)` que inicialice DB para tests (`database.InitForTesting()`), ejecute migraciones del modelo del módulo, cree repository → service → handler y devuelva el handler.
-- **Errores:** Helper `DecodeErrorResponse(test, body)` que decodifique el body en `runtimeError.ErrorResponse` para afirmar `errorResponse.Error.Code`.
-- **Casos:** Por endpoint, incluir al menos un test de éxito y tests por tipo de error (401, 404, 422, 409, etc.) según aplique.
+- Parámetro **`test *testing.T`** (nunca `t`) en tests y helpers.
+- `Setup{Resource}HandlerTest(test)` → `database.InitForTesting()`, migraciones del modelo, repo → service → handler.
+- `DecodeErrorResponse(test, body)` → `runtimeError.ErrorResponse`; assert `errorResponse.Error.Code`.
+- Por endpoint: al menos un éxito + errores relevantes (401, 404, 422, 409, …).
 
----
+## Estilo
 
-## Estilo de código
+- Imports: std → third → internal; líneas en blanco entre grupos.
+- Alias camelCase para paquetes de una palabra ambigua: `runtimeError "…/runtimeerror"`.
+- Variables camelCase; exportados PascalCase.
+- Código y comentarios en **inglés**.
+- Nombres explícitos: `userRepository`, no `userRepo`; params `repository`, `service`, `handler`, `request`, `response`. OK: `err`, `ctx`, `id`, `req`/`resp` HTTP. Receivers descriptivos si hay varios.
 
-- **Imports:** Ordenar: estándar → terceros → internal. Agrupar con líneas en blanco.
-- **Alias de import:** Para paquetes cuyo nombre es una sola palabra en minúsculas que se lee como compuesta (ej. `runtimeerror`), usar alias en camelCase para mejorar legibilidad: `runtimeError "github.com/cloudflax/api.cloudflax/internal/shared/runtimeerror"`.
-- **Variables:** camelCase. Constantes y tipos exportados: PascalCase.
-- **Comentarios:** Siempre en inglés. Todo el código fuente debe estar íntegramente en inglés.
+## Documentación del módulo
 
-### Nombres descriptivos (Clean Code)
+1. **Godoc:** comentario antes de `package` empezando por `Package <name> …`.
+2. **`README.md`** en el feature: arquitectura, modelo/datos, errores + HTTP, middlewares/validaciones/integraciones.
 
-Evitar abreviaciones y nombres cortos que obligan al lector a “traducir” mentalmente. Preferir nombres que revelen la intención.
+## JSON API
 
-- **No abreviar:** Preferir `userRepository`, `userService`, `userHandler` en lugar de `userRepo`, `userSvc`, `userHnd`.
-- **En parámetros y variables:** Usar nombres completos como `repository`, `service`, `handler`, `user`, `request`, `response`.
-- **Excepciones ampliamente conocidas:** `err` (error), `ctx` (context), `id`, `req`/`resp` en contexto HTTP — son convenciones estándar y legibles.
-- **Receivers:** Go acepta receivers de 1–2 letras; usar nombres descriptivos cuando mejoren la claridad (ej. `repository` o `svc` en lugar de `r` si hay varios receivers).
-
----
-
-## Documentación de módulos
-
-Cada módulo en `internal/{recurso}/` debe documentarse de dos formas:
-
-1. **Comentario de paquete (godoc):** En al menos un archivo `.go` del paquete, incluir un comentario inmediatamente antes de `package ...` que empiece por `Package <nombre>`. Es el texto que muestra `go doc` y pkg.go.dev. Ejemplo:
-   ```go
-   // Package user provides user identity management: profile CRUD, password
-   // hashing, soft delete, and session revocation.
-   package user
-   ```
-
-2. **README.md:** En la carpeta del módulo, un `README.md` con arquitectura del feature, modelo de datos (tablas/campos), diccionario de errores y códigos HTTP, y consideraciones técnicas (middlewares, validaciones, integraciones). Sirve como documentación para el equipo y onboarding.
-
-Los comentarios de tipos y funciones exportados siguen las reglas de **Estilo de código** (en inglés).
-
----
-
-## Formato de respuesta JSON
+Códigos y helpers: `internal/shared/runtimeerror/runtimeerror.go`; `runtimeerror.Respond` y `runtimeerror.RespondWithDetails` construyen la forma de error.
 
 **Éxito:**
+
 ```json
 {
   "data": { ... },
@@ -145,6 +86,7 @@ Los comentarios de tipos y funciones exportados siguen las reglas de **Estilo de
 ```
 
 **Error (único):**
+
 ```json
 {
   "error": {
@@ -156,7 +98,8 @@ Los comentarios de tipos y funciones exportados siguen las reglas de **Estilo de
 }
 ```
 
-**Error (múltiples campos — validación):**
+**Error (validación, varios campos):**
+
 ```json
 {
   "error": {
@@ -172,19 +115,26 @@ Los comentarios de tipos y funciones exportados siguen las reglas de **Estilo de
 }
 ```
 
-Los códigos de error se definen en `internal/shared/runtimeerror/runtimeerror.go`. Los helpers `runtimeerror.Respond` y `runtimeerror.RespondWithDetails` construyen siempre esta estructura.
+**Lista paginada:** mismo contenedor de éxito; añadir `meta` con `page`, `limit`, `total`.
 
-Para listas paginadas, incluir `meta` con `page`, `limit`, `total`.
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "page": 1,
+    "limit": 20,
+    "total": 100
+  }
+}
+```
 
----
+## Status HTTP
 
-## Status codes por operación
-
-| Operación | Éxito | Errores frecuentes |
-|-----------|-------|---------------------|
-| List | 200 | 400 (query inválida) |
-| Get by ID | 200 | 404 (no encontrado) |
-| Create | 201 | 400 (validación), 409 (duplicado) |
-| Update | 200 | 400 (validación), 404 (no encontrado) |
-| Delete | 200 o 204 | 404 (no encontrado) |
-| Login | 200 | 401 (credenciales inválidas) |
+| Operación | OK | Errores típicos |
+|-----------|-----|-----------------|
+| List | 200 | 400 query |
+| Get | 200 | 404 |
+| Create | 201 | 400, 409 duplicado |
+| Update | 200 | 400, 404 |
+| Delete | 200 o 204 | 404 |
+| Login | 200 | 401 |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,60 +1,27 @@
-# Skills — Cloudflax API
+# Skills | Cloudflax - Backend
 
-Capacidades y conocimientos esperados para trabajar en este proyecto.
+Expectativas y stack para agente y contribuidores.
 
----
+## Expectativas (respuestas)
 
-## Skill Expectations
+- **Senior backend + Go**: no explicar HTTP/REST, DB ni sintaxis Go básica; ir al punto.
+- **Prioridad**: arquitectura, patrones y tradeoffs frente a tutoriales genéricos.
 
-- **Assume senior backend knowledge** — No explicar conceptos básicos de backend, HTTP o bases de datos.
-- **Do not explain basic Go syntax** — Asumir dominio de Go. Ir directo al punto.
-- **Focus on architecture and tradeoffs** — Priorizar decisiones de diseño, patrones y pros/contras.
+## Agente — dominio y stack
 
----
+| Tema | Contenido |
+|------|-----------|
+| **Go 1.25+** | context, `fmt.Errorf` con `%w`, interfaces, goroutines básicas |
+| **Fiber v3** | router, middleware, handlers, `ctx.JSON` / bind / `Params` |
+| **GORM** | modelos, migraciones, Create/First/Where, preload, scopes |
+| **PostgreSQL** | tipos, constraints, índices, UUID como PK |
+| **SQLite** | tests in-memory (p. ej. glebarez/sqlite) |
+| **slog** | Info/Error, logs estructurados, context |
+| **Tests** | testify, mocks |
+| **Validación** | go-playground/validator, tags `validate:"..."` |
+| **Arquitectura** | Handler → Service → Repository, por feature, DTOs |
+| **Tooling** | golangci-lint, Docker / devcontainer, Makefile (build, test, lint, test-cover) |
 
-## Skills del agente
+## Contribuidores humanos
 
-El agente de IA debe dominar:
-
-| Área | Conocimiento requerido |
-|------|------------------------|
-| **Go** | Sintaxis 1.25+, context, error handling con `%w`, interfaces, goroutines básicas |
-| **Fiber v3** | Router, handlers, middleware, `ctx.JSON()`, `ctx.Params()`, request bind |
-| **GORM** | Modelos, migraciones, `db.Create()`, `db.First()`, `db.Where()`, preload, scopes |
-| **PostgreSQL** | Tipos, constraints, índices, UUID como PK |
-| **slog** | `slog.Info`, `slog.Error`, structured logging, context |
-| **Testing** | testify, mocks, SQLite in-memory para tests rápidos |
-| **Validación** | go-playground/validator, tags `validate:"required,email"` |
-| **Arquitectura** | Handler → Service → Repository, feature-driven, DTOs |
-
----
-
-## Skills del equipo
-
-Quien contribuya debe conocer:
-
-- **Go** — Nivel intermedio (structs, interfaces, error handling, tests)
-- **HTTP/REST** — Verbos, status codes, JSON
-- **Bases de datos relacionales** — Modelado, relaciones, queries
-- **Docker** — Básico (devcontainer, docker-compose)
-- **Git** — Branching, commits, pre-commit
-
----
-
-## Skills del proyecto
-
-Tecnologías y prácticas del stack:
-
-| Tecnología | Uso |
-|------------|-----|
-| **Go 1.25** | Lenguaje principal |
-| **Fiber v3** | Framework HTTP |
-| **GORM** | ORM, migraciones |
-| **PostgreSQL** | Base de datos principal |
-| **SQLite** | Tests (glebarez/sqlite in-memory) |
-| **slog** | Logging estructurado |
-| **testify** | Assertions y mocks |
-| **golangci-lint** | Linter |
-| **go-playground/validator** | Validación de entrada |
-| **Docker / Devcontainer** | Entorno de desarrollo |
-| **Makefile** | build, test, lint, test-cover |
+Go intermedio (structs, interfaces, errores, tests), REST/JSON, SQL relacional, Docker básico (devcontainer, compose), Git (ramas, commits, pre-commit).

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cloudflax/api.cloudflax/internal/user"
 )
 
+// En: Bootstraps config, database, migrations, then starts the API server.
+// Es: Inicializa config, base de datos, migraciones y arranca el servidor API.
 func main() {
 	logger.Init(os.Getenv("LOG_LEVEL"))
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -12,7 +12,9 @@ Ante trabajo trazable (feature, cambio de comportamiento, refactor relevante), *
 
 ## Issues y ramas
 
-Creación: `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (nombre del project exacto). Cuerpo con objetivos técnicos y criterios de aceptación. Rama: `feature/<ID_ISSUE>-<slug>`; el `#ID` debe existir antes. Ramas dedicadas para revisiones o paralelismo; no forzar para micro-cambios.
+Creación: `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (nombre del project exacto). Cuerpo con objetivos y criterios de aceptación. Rama: `feature/<ID_ISSUE>-<slug>`; el `#ID` debe existir antes. Ramas dedicadas para revisiones o paralelismo; no forzar para micro-cambios.
+
+**Primera creación (misma pasada):** issue con `--assignee cloudflax` y `--label …` si el CLI lo permite; en el project, **Priority** y **Size** siempre con valor (no dejar el select vacío). **Estimate** y fechas solo con criterio o acuerdo; si no hay, indicarlo en el cuerpo — no inventar. Assignee alternativo si `cloudflax` no aplica en el org.
 
 ## Cierre y commits
 
@@ -24,11 +26,7 @@ Mantén **Status** alineado con la realidad. Valores: **Backlog**, **Ready**, **
 
 ## Project: Priority, Size, Estimate, fechas
 
-Además de Status, rellenar desde la IA cuando aplique: **Priority** y **Size** (single select) — proponer tras entender alcance e impacto, alinear vocabulario con el tablero. **Estimate** (número), **Start date** y **Target date** — solo con acuerdo explícito del usuario o política del equipo; no inventar fechas ni números.
-
-CLI: `gh project list --owner cloudflax` (project id); `gh project field-list <n> --owner cloudflax` (field ids y option ids); localizar `item-id` con `gh project item-list`. Un campo por comando: `gh project item-edit --project-id … --id <item-id> --field-id …` + `--single-select-option-id …` | `--number …` | `--date YYYY-MM-DD` | `--clear`.
-
-Orden sugerido: crear issue → enlace al project → Priority/Size cuando el alcance esté claro → Estimate/fechas si hay criterio.
+CLI: `gh project list --owner cloudflax` → `gh project field-list <n> --owner cloudflax` → `item-id` vía `gh project item-list`. Editar: `gh project item-edit --project-id … --id <item-id> --field-id …` + `--single-select-option-id …` | `--number …` | `--date YYYY-MM-DD` | `--clear`. Issue: `gh issue edit <n> --add-assignee cloudflax --add-label "<label>"`.
 
 ## Tooling
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,44 +1,35 @@
 # GitHub Workflow & Traceability (`cloudflax/api.cloudflax`)
 
-Actúa como un agente de desarrollo senior integrado en el repositorio `cloudflax/api.cloudflax`. Tu objetivo es garantizar la trazabilidad total del trabajo siguiendo estrictamente este protocolo de comandos y jerarquía.
+Agente integrado en este repo: trazabilidad vía GitHub Issues/Project y ramas. No ejecutes Issue + rama + PR sin señal del usuario.
 
-## 1. Protocolo de Inicio y Autonomía
-* **Detección de Tarea:** Ante cualquier trabajo trazable (features, cambios de comportamiento o refactors relevantes), **pregunta obligatoriamente** al usuario si desea iniciar el flujo de trazabilidad.
-* **Restricción de Ejecución:** No asumas ni ejecutes el flujo completo (Issue + Rama + PR) de forma automática. Sigue esta matriz de decisión:
+## Inicio
 
-| Input del Usuario | Acción Obligatoria del Agente |
-| :--- | :--- |
-| **"Sí, rama + trazabilidad"** | 1. Crear Issue en `@api.cloudflax`. <br> 2. Obtener el `#ID`. <br> 3. Crear rama `feature/<ID>-<slug>`. |
-| **"Solo crear tarea"** | Crear únicamente la Issue en el Project. No crear rama hasta nueva orden. |
+Ante trabajo trazable (feature, cambio de comportamiento, refactor relevante), **pregunta** si quiere flujo de trazabilidad. Matriz:
 
-## 2. Gestion de Issues y Projects
-* **Comando de Creación:** Usa `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"`.
-* **Project Board:** Es obligatorio asignar la Issue al proyecto de la organización **`@api.cloudflax`**. El nombre debe coincidir exactamente.
-* **Contenido:** La Issue debe incluir objetivos técnicos claros y criterios de aceptación antes de proceder.
+- **Sí, rama + trazabilidad** → crear Issue en `@api.cloudflax`, anotar `#ID`, rama `feature/<ID>-<slug-kebab>`.
+- **Solo crear tarea** → solo Issue en el project; sin rama hasta nueva orden.
+- **Solo commits (rama ya ligada al issue)** → ya estás en `feature/<ID>-<slug>` (o equivalente donde el prefijo numérico sea el id del issue); no crear issue ni rama nueva. Commits en **inglés** y Conventional Commits, cuerpo o pie con **`Refs #ID`** o **`Closes #ID`** según cierre real; sin `push`/PR salvo petición explícita (igual que en [Cierre y commits](#cierre-y-commits)).
 
-## 3. Estándar de Ramas (Branching)
-* **Formato:** `feature/<ID_ISSUE>-<slug-corto-en-kebab>` (Ejemplo: `feature/7-auth-fix`).
-* **Dependencia:** El número de la Issue **debe existir antes** de nombrar y crear la rama.
-* **Uso:** Prioriza ramas dedicadas para revisiones aisladas o trabajos en paralelo. No fuerces ramas para micro-ediciones mínimas.
+## Issues y ramas
 
-## 4. Desarrollo y Cierre (Loop de Feedback)
-* **Iteración:** El código se desarrolla mediante diálogo. No realices `git push` o `PR` de forma proactiva al terminar de escribir código.
-* **Ejecución de Cierre:** Ejecuta `git commit`, `git push` y `gh pr create` **solo bajo petición explícita** o cuando se acuerde un cierre autónomo en la sesión.
-* **Vinculación en PR:** La descripción del PR debe incluir `Closes #ID` o `Refs #ID` para vincular la actividad.
+Creación: `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (nombre del project exacto). Cuerpo con objetivos técnicos y criterios de aceptación. Rama: `feature/<ID_ISSUE>-<slug>`; el `#ID` debe existir antes. Ramas dedicadas para revisiones o paralelismo; no forzar para micro-cambios.
 
-## 5. Estandares de Git y Commits
-* **Idioma:** Mensajes de commit y descripciones siempre en **inglés**.
-* **Formato:** Usa *Conventional Commits* (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).
-* **Integridad:** Prohibido usar `git commit --amend` o reescribir historial en ramas remotas salvo petición expresa.
+## Cierre y commits
 
-## 6. Sincronizacion del Tablero Project
-* Actualiza el campo **Status** del Project de forma síncrona con el estado real del PR y la Issue. Los valores del tablero son:
-  * **Backlog** — This item hasn't been started.
-  * **Ready** — This is ready to be picked up.
-  * **In progress** — This is actively being worked on.
-  * **In review** — This item is in review.
-  * **Done** — This has been completed.
-* Flujo típico: `Backlog` → `Ready` → `In progress` → `In review` → `Done` (ajusta según el punto en el que esté el trabajo).
+No hagas `git push` ni PR al acabar código salvo petición explícita o acuerdo en sesión. PR: `Closes #ID` o `Refs #ID`. Commits y descripciones en **inglés**; Conventional Commits (`feat:`, `fix:`, …). Si la rama sigue `feature/<ID>-…`, usa ese **mismo `#ID`** en el mensaje para asociar el commit al issue. Sin `git commit --amend` ni reescritura de historial remoto salvo petición expresa.
 
-## 7. Troubleshooting de Tooling
-* Si detectas errores de permisos o scopes de GitHub CLI (`project`, `read:project`), solicita al usuario ejecutar `gh auth refresh` o el comando de autenticación correspondiente antes de reintentar.
+## Project: Status
+
+Mantén **Status** alineado con la realidad. Valores: **Backlog**, **Ready**, **In progress**, **In review**, **Done**. Flujo típico en ese orden.
+
+## Project: Priority, Size, Estimate, fechas
+
+Además de Status, rellenar desde la IA cuando aplique: **Priority** y **Size** (single select) — proponer tras entender alcance e impacto, alinear vocabulario con el tablero. **Estimate** (número), **Start date** y **Target date** — solo con acuerdo explícito del usuario o política del equipo; no inventar fechas ni números.
+
+CLI: `gh project list --owner cloudflax` (project id); `gh project field-list <n> --owner cloudflax` (field ids y option ids); localizar `item-id` con `gh project item-list`. Un campo por comando: `gh project item-edit --project-id … --id <item-id> --field-id …` + `--single-select-option-id …` | `--number …` | `--date YYYY-MM-DD` | `--clear`.
+
+Orden sugerido: crear issue → enlace al project → Priority/Size cuando el alcance esté claro → Estimate/fechas si hay criterio.
+
+## Tooling
+
+Errores de permisos o scopes (`project`, `read:project`): pedir al usuario `gh auth refresh` (u auth adecuada) antes de reintentar.

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,51 +1,44 @@
-# GitHub — Issue, proyecto `@api.cloudflax`, rama y PR
+# GitHub Workflow & Traceability (`cloudflax/api.cloudflax`)
 
-Directrices para trabajo **trazable** en `cloudflax/api.cloudflax` (features, cambios de comportamiento, refactors relevantes). No hace falta seguir este flujo para ediciones mínimas acordadas.
+Actúa como un agente de desarrollo senior integrado en el repositorio `cloudflax/api.cloudflax`. Tu objetivo es garantizar la trazabilidad total del trabajo siguiendo estrictamente este protocolo de comandos y jerarquía.
 
----
+## 1. Protocolo de Inicio y Autonomía
+* **Detección de Tarea:** Ante cualquier trabajo trazable (features, cambios de comportamiento o refactors relevantes), **pregunta obligatoriamente** al usuario si desea iniciar el flujo de trazabilidad.
+* **Restricción de Ejecución:** No asumas ni ejecutes el flujo completo (Issue + Rama + PR) de forma automática. Sigue esta matriz de decisión:
 
-## 1. Issue
+| Input del Usuario | Acción Obligatoria del Agente |
+| :--- | :--- |
+| **"Sí, rama + trazabilidad"** | 1. Crear Issue en `@api.cloudflax`. <br> 2. Obtener el `#ID`. <br> 3. Crear rama `feature/<ID>-<slug>`. |
+| **"Solo crear tarea"** | Crear únicamente la Issue en el Project. No crear rama hasta nueva orden. |
 
-Crea la tarea en `cloudflax/api.cloudflax` con objetivos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con:
+## 2. Gestion de Issues y Projects
+* **Comando de Creación:** Usa `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"`.
+* **Project Board:** Es obligatorio asignar la Issue al proyecto de la organización **`@api.cloudflax`**. El nombre debe coincidir exactamente.
+* **Contenido:** La Issue debe incluir objetivos técnicos claros y criterios de aceptación antes de proceder.
 
-```bash
-gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"
-```
+## 3. Estándar de Ramas (Branching)
+* **Formato:** `feature/<ID_ISSUE>-<slug-corto-en-kebab>` (Ejemplo: `feature/7-auth-fix`).
+* **Dependencia:** El número de la Issue **debe existir antes** de nombrar y crear la rama.
+* **Uso:** Prioriza ramas dedicadas para revisiones aisladas o trabajos en paralelo. No fuerces ramas para micro-ediciones mínimas.
 
-El nombre del project debe coincidir **exactamente** con el de GitHub.
+## 4. Desarrollo y Cierre (Loop de Feedback)
+* **Iteración:** El código se desarrolla mediante diálogo. No realices `git push` o `PR` de forma proactiva al terminar de escribir código.
+* **Ejecución de Cierre:** Ejecuta `git commit`, `git push` y `gh pr create` **solo bajo petición explícita** o cuando se acuerde un cierre autónomo en la sesión.
+* **Vinculación en PR:** La descripción del PR debe incluir `Closes #ID` o `Refs #ID` para vincular la actividad.
 
----
+## 5. Estandares de Git y Commits
+* **Idioma:** Mensajes de commit y descripciones siempre en **inglés**.
+* **Formato:** Usa *Conventional Commits* (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`).
+* **Integridad:** Prohibido usar `git commit --amend` o reescribir historial en ramas remotas salvo petición expresa.
 
-## 2. Rama
+## 6. Sincronizacion del Tablero Project
+* Actualiza el campo **Status** del Project de forma síncrona con el estado real del PR y la Issue. Los valores del tablero son:
+  * **Backlog** — This item hasn't been started.
+  * **Ready** — This is ready to be picked up.
+  * **In progress** — This is actively being worked on.
+  * **In review** — This item is in review.
+  * **Done** — This has been completed.
+* Flujo típico: `Backlog` → `Ready` → `In progress` → `In review` → `Done` (ajusta según el punto en el que esté el trabajo).
 
-Formato: `feature/<número-de-issue>-<slug-corto-en-kebab>` (ej. `feature/3-agents-md-hub`).
-
-**Rama dedicada:** Ábrela cuando aporte (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). No fuerces rama para cada microcambio si el equipo acuerda lo contrario.
-
----
-
-## 3. Asociación issue ↔ rama ↔ PR
-
-Desarrolla en la rama vinculada a la issue. En el **PR**, incluye `Closes #N` o `Refs #N` en la descripción para vincular la issue.
-
-Opcionalmente deja un comentario en la issue indicando el nombre de la rama.
-
----
-
-## 4. Tablero (project)
-
-Actualiza **Status** y demás campos del project (p. ej. *Ready* → *In review* → *Done*) según el estado real del trabajo.
-
----
-
-## 5. Commits
-
-- Mensajes en **inglés**.
-- Conventional Commits cuando encaje (`feat`, `fix`, …).
-- No reescribas historia en remoto con `--amend` salvo petición explícita.
-
----
-
-## 6. CLI `gh` y permisos
-
-Hacen falta scopes adecuados (`project`, `read:project`). Si falta permiso o login interactivo, ejecuta `gh auth refresh` (u otro paso que indique `gh`).
+## 7. Troubleshooting de Tooling
+* Si detectas errores de permisos o scopes de GitHub CLI (`project`, `read:project`), solicita al usuario ejecutar `gh auth refresh` o el comando de autenticación correspondiente antes de reintentar.

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,0 +1,51 @@
+# GitHub — Issue, proyecto `@api.cloudflax`, rama y PR
+
+Directrices para trabajo **trazable** en `cloudflax/api.cloudflax` (features, cambios de comportamiento, refactors relevantes). No hace falta seguir este flujo para ediciones mínimas acordadas.
+
+---
+
+## 1. Issue
+
+Crea la tarea en `cloudflax/api.cloudflax` con objetivos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con:
+
+```bash
+gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"
+```
+
+El nombre del project debe coincidir **exactamente** con el de GitHub.
+
+---
+
+## 2. Rama
+
+Formato: `feature/<número-de-issue>-<slug-corto-en-kebab>` (ej. `feature/3-agents-md-hub`).
+
+**Rama dedicada:** Ábrela cuando aporte (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). No fuerces rama para cada microcambio si el equipo acuerda lo contrario.
+
+---
+
+## 3. Asociación issue ↔ rama ↔ PR
+
+Desarrolla en la rama vinculada a la issue. En el **PR**, incluye `Closes #N` o `Refs #N` en la descripción para vincular la issue.
+
+Opcionalmente deja un comentario en la issue indicando el nombre de la rama.
+
+---
+
+## 4. Tablero (project)
+
+Actualiza **Status** y demás campos del project (p. ej. *Ready* → *In review* → *Done*) según el estado real del trabajo.
+
+---
+
+## 5. Commits
+
+- Mensajes en **inglés**.
+- Conventional Commits cuando encaje (`feat`, `fix`, …).
+- No reescribas historia en remoto con `--amend` salvo petición explícita.
+
+---
+
+## 6. CLI `gh` y permisos
+
+Hacen falta scopes adecuados (`project`, `read:project`). Si falta permiso o login interactivo, ejecuta `gh auth refresh` (u otro paso que indique `gh`).

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -18,7 +18,7 @@ Creación: `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (nom
 
 ## Cierre y commits
 
-No hagas `git push` ni PR al acabar código salvo petición explícita o acuerdo en sesión. PR: `Closes #ID` o `Refs #ID`. Commits y descripciones en **inglés**; Conventional Commits (`feat:`, `fix:`, …). Si la rama sigue `feature/<ID>-…`, usa ese **mismo `#ID`** en el mensaje para asociar el commit al issue. Sin `git commit --amend` ni reescritura de historial remoto salvo petición expresa.
+No hagas `git push` ni PR al acabar código salvo petición explícita o acuerdo en sesión. PR: `Closes #ID` o `Refs #ID`. Commits y descripciones en **inglés**; Conventional Commits (`feat:`, `fix:`, …). Antes de crear cada commit, **lee el nombre de la rama actual** para obtener el ID de la tarea (por ejemplo `feature/3-agents-md-hub` -> `#3`) y usa ese **mismo `#ID`** en el cuerpo o pie del commit con `Refs #ID` o `Closes #ID` según corresponda. Sin `git commit --amend` ni reescritura de historial remoto salvo petición expresa.
 
 ## Project: Status
 


### PR DESCRIPTION
## Summary
Restructures `AGENTS.md` as the primary entry point for Cursor agents: documentation map, checklist, compact rules, and numbered GitHub workflow with explicit issue–branch–PR linkage.

## Details
- Links to `CONVENTIONS.md`, `ARCHITECTURE.md`, `README.md`, `SKILLS.md`, `AUTH_INTEGRATION.md`, `docs/ACCOUNTS_AND_DATA_OWNERSHIP.md`, and feature `README.md` files.
- Removes duplicated long-form content in favor of cross-references.
- Keeps agent-specific essentials (lint/test, migrations, logging/PII, traceable work) visible without repeating full convention tables.

## Testing
- `make test` passed locally.

Closes #3

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime code, APIs, or data handling.
> 
> **Overview**
> `AGENTS.md` is reorganized into a short **entry-point** for Cursor agents: a documentation map with links to canonical guides, a pre-change checklist (lint/tests, migrations, logging/PII), compact rules, and a small communication checklist.
> 
> A new `docs/GITHUB_WORKFLOW.md` is added to hold the detailed, numbered issue→branch→PR traceability process (including `gh` commands, branch naming, and when the agent may commit/push/open PRs), replacing the long inlined workflow text previously in `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ac2c72c3b0f050cbc8a8c31c5b031026fd91101. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->