### PR TITLE
docs: agent rules and GitHub workflow traceability

### DIFF
--- a/.cursor/rules/go-bilingual-comments.mdc
+++ b/.cursor/rules/go-bilingual-comments.mdc
@@ -1,0 +1,13 @@
+---
+description: Comentarios Go bilingües (En/Es) — doc de package sin mezcla; bilingüe solo en declaraciones exportadas.
+globs: "**/*.go"
+alwaysApply: true
+---
+
+# Comentarios Go (bilingüe En/Es)
+
+- **Doc de `package`:** una sola lengua en el bloque (español *o* inglés), sin alternancia línea a línea dentro del mismo doc.
+- **Declaraciones exportadas** (`func`, `type`, `const`, `var` visibles fuera del paquete): comentario doc puede ser bilingüe cuando el equipo lo use (p. ej. primera frase EN, segunda ES, o bloques claros separados).
+- **Comentarios en el cuerpo** (dentro de funciones, ramas, bucles): **una sola lengua** por comentario; no mezclar En/Es en comentarios de líneas internas salvo cita literal o término técnico puntual.
+
+El código (identificadores, mensajes de error de API) sigue [CONVENTIONS.md](../../CONVENTIONS.md) y [docs/AGENT_RULES.md](../../docs/AGENT_RULES.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,21 @@
-## Agents — Cloudflax API (Backend)
+## Agents | Cloudflax - Backend
 
-Este documento establece las directrices operativas que deben seguir los agentes de Cursor para garantizar la robustez, seguridad y escalabilidad de la API de Cloudflax.
+Instrucciones para quien ejecuta tareas en este repo (agente). Prioriza [docs/AGENT_RULES.md](./docs/AGENT_RULES.md) y la tabla siguiente; cada fila enlaza el detalle cuando aplica.
 
-## Stack tecnológico
+Abre una **referencia solo cuando aplique** a la tarea (tabla siguiente). No cargues documentación que no necesites.
 
-- **Lenguaje**: Go 1.25
-- **Framework**: Fiber v3
-- **ORM**: GORM (PostgreSQL)
-- **Observabilidad**: slog (Structured Logging)
+### Acción → referencia
 
-## Convenciones de Código y Naming
+| Acción | Referencia |
+|--------|------------|
+| Entorno, `make`, árbol del repo | [README.md](./README.md) |
+| Stack, capas, middleware, migraciones | [ARCHITECTURE.md](./ARCHITECTURE.md) |
+| API, errores, JSON, tests | [CONVENTIONS.md](./CONVENTIONS.md) |
+| Issues, ramas, PR, commits | [docs/GITHUB_WORKFLOW.md](./docs/GITHUB_WORKFLOW.md) |
+| Nivel y foco de tus respuestas | [SKILLS.md](./SKILLS.md) |
+| Contrato auth (JWT, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
+| Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
+| Comentarios Go (sin En/Es en doc de `package`; En/Es solo en declaraciones, no en sentencias internas) | [`.cursor/rules/go-bilingual-comments.mdc`](./.cursor/rules/go-bilingual-comments.mdc) (siempre activo en Cursor) |
+| Obligaciones del agente (lint/test, GORM, GitHub, logs, docs; respuesta al humano; stack) | [docs/AGENT_RULES.md](./docs/AGENT_RULES.md) |
 
-- **Idioma**: El código fuente, logs y mensajes de error deben ser estrictamente en **inglés**.
-- **Naming CRUD**: Sigue el patrón `List{Resource}`, `Get{Resource}`, `Create{Resource}`, `Update{Resource}`.
-- **Funciones**: Mantén una lógica simple; máximo ~50 líneas por función y no más de 4 parámetros.
-
-## Arquitectura y Datos
-
-- **Estructura de Carpetas**: Implementa cada recurso en `internal/{recurso}/` con sus capas correspondientes:
-  - `model.go`: Definición de estructuras y tags de GORM.
-  - `repository.go`: Consultas directas a la base de datos.
-  - `service.go`: Lógica de negocio y validaciones.
-  - `handler.go`: Controladores de Fiber (entrada/salida).
-- **Gestión de Errores**: Usa `fmt.Errorf` con el verbo `%w` para mantener la trazabilidad. Nunca ignores un error.
-- **Migraciones**: Si modificas un modelo, registra la migración en `database.RunMigrations()` dentro de `cmd/api/main.go`.
-
-## Seguridad operativa y herramientas
-
-- **Logs**: Usa `slog`. Queda terminantemente prohibido loguear datos sensibles (passwords, tokens, PII).
-- **Makefile**: Usa `make lint` y `make test` como validación obligatoria antes de proponer cambios.
-- **Entorno**: El entorno de trabajo es `/app` dentro de un Devcontainer.
-
-
-## Handlers HTTP y respuestas
-
-- **Consistencia en respuestas**: Estandariza la forma de responder errores y éxitos (status code + payload JSON con `message`, `data` opcional y/o `error`).
-- **Validación de entrada**: Valida siempre parámetros de ruta, query y body en la capa `handler` o `service` antes de llamar al repositorio.
-- **Errores HTTP**: Mapea los errores de negocio a códigos HTTP claros (`400` validación, `401`/`403` auth/autorización, `404` no encontrado, `409` conflicto, `500` errores inesperados).
-
-## Logging y observabilidad
-
-- **Niveles de log**: Usa `Debug` para detalle de desarrollo, `Info` para flujos exitosos importantes, `Warn` para situaciones anómalas recuperables y `Error` para fallos que requieren atención.
-- **Contexto estructurado**: Incluye siempre campos relevantes (por ejemplo `request_id`, `user_id`, `resource`, `operation`) usando `slog` con atributos estructurados.
-- **Trazabilidad**: Propaga un identificador de correlación por request (por ejemplo, `X-Request-ID`) y loguéalo en todos los puntos clave.
-- **No PII**: Nunca incluyas en logs passwords, tokens, credenciales, ni datos sensibles de usuarios.
-
-## Pruebas
-
-- **Cobertura mínima**: Cada nueva funcionalidad debe incluir tests de unidad para servicios y, cuando aplique, tests de integración para repositorios y endpoints críticos.
-- **make test**: Ejecuta `make test` antes de abrir un PR; no se deben introducir fallos en el pipeline de tests.
-- **Aislamiento**: Evita dependencias externas no deterministas en tests (red, tiempos reales, etc.); usa dobles de prueba o fixtures controlados.
-
-## Acceso a datos y rendimiento
-
-- **Paginación obligatoria**: En listados (`List{Resource}`) implementa paginación por defecto para evitar lecturas masivas en memoria.
-- **Consultas eficientes**: Revisa índices y uso de `SELECT` específicos; evita `SELECT *` en consultas críticas.
-- **Transacciones**: Usa transacciones en el repositorio cuando varias operaciones deban ser atómicas.
-
-## Seguridad
-
-- **Validación y saneamiento**: Valida y normaliza toda entrada externa antes de usarla en queries o lógica sensible.
-- **Principio de mínimo privilegio**: Diseña servicios y consultas asumiendo el menor conjunto posible de permisos y datos expuestos.
-- **Gestión de secretos**: Nunca hardcodees secretos o credenciales en el repositorio; deben provenir de variables de entorno o sistemas seguros.
-
-## Flujo de trabajo y PRs
-
-- **Antes de abrir un PR**:
-  - Ejecuta `make lint` y `make test` y asegúrate de que pasan.
-  - Revisa que no haya logs de depuración temporales ni comentarios obsoletos.
-- **Durante la revisión**:
-  - Explica brevemente el propósito del cambio y cualquier decisión no obvia.
-  - Acepta y responde comentarios en inglés dentro del código, manteniendo la descripción funcional en español en la conversación con el usuario.
-
-### GitHub: issue, proyecto `@api.cloudflax`, rama y PR (cuando aplique)
-
-Para trabajo **trazable** (features, cambios de comportamiento, refactors relevantes), sigue este flujo **sin tratarlo como obligatorio para cada edición mínima**.
-
-- **¿Rama nueva?** Abre rama dedicada **solo cuando aporte** (varios commits, revisión aislada, riesgo en `main`, trabajo en paralelo). Los ajustes triviales acordados pueden integrarse sin rama si el equipo lo permite; no fuerces rama por defecto.
-- **Issue**: Crea la tarea en `cloudflax/api.cloudflax` con objetivos técnicos y criterios de aceptación. Enlázala al project de organización **`@api.cloudflax`** con `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"` (el título del project debe coincidir **exactamente** con GitHub).
-- **Etiquetas y tablero**: Asigna labels del repo cuando corresponda y mantén los campos del project alineados con la realidad (**Status**, Priority, Size, Estimate, fechas): p. ej. *Ready* cuando el código está listo para PR, *In review* al abrir el PR, *Done* tras merge a `main`.
-- **Nombre de rama** (si usas rama): `feature/<número-de-issue>-<slug-corto-en-kebab>` una vez conocido el `#` de la issue (ej. `feature/1-enhance-jwt-handling-config`). Evita slugs genéricos sin número si la issue ya existe.
-- **Commits**: Mensajes en **inglés**; convención tipo Conventional Commits cuando encaje (`feat`, `fix`, etc.). La vinculación fuerte a la issue va en el **PR**: incluye `Closes #N` o `Refs #N` en la descripción. Repetir `#N` en cada commit es **opcional**; si la rama ya está en remoto, no reescribas historia con `--amend` salvo petición explícita.
-- **PR**: Crea el PR contra `main` con resumen del cambio y `Closes #N` cuando el merge deba cerrar la issue.
-- **`gh` y permisos**: Para issues y Projects hace falta token con scopes adecuados (`project`, `read:project`). Si `gh` pide ampliar permisos o login interactivo, **indícalo al usuario** para que ejecute `gh auth refresh` (u otro paso interactivo); no sustituyas tú ese login en el agente.
-
-## Flujo de Comunicación
-
-- Explica los cambios en español de forma concisa.
-- Informa proactivamente si los cambios afectan al archivo `.env` o requieren una migración de base de datos.
+**Obligaciones y respuesta al humano:** lista y detalle en [docs/AGENT_RULES.md](./docs/AGENT_RULES.md) (incluye qué hacer si no abres otro doc).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Abre una **referencia solo cuando aplique** a la tarea (tabla siguiente). No car
 | Nivel y foco de tus respuestas | [SKILLS.md](./SKILLS.md) |
 | Contrato auth (JWT, cookies) | [AUTH_INTEGRATION.md](./AUTH_INTEGRATION.md) |
 | Cuentas y titularidad de datos | [docs/ACCOUNTS_AND_DATA_OWNERSHIP.md](./docs/ACCOUNTS_AND_DATA_OWNERSHIP.md) |
-| Comentarios Go (sin En/Es en doc de `package`; En/Es solo en declaraciones, no en sentencias internas) | [`.cursor/rules/go-bilingual-comments.mdc`](./.cursor/rules/go-bilingual-comments.mdc) (siempre activo en Cursor) |
+| Comentarios Go (sin En/Es en doc de `package`; En/Es solo en declaraciones, no en sentencias internas) | [.cursor/rules/go-bilingual-comments.mdc](./.cursor/rules/go-bilingual-comments.mdc) (siempre activo en Cursor) |
 | Obligaciones del agente (lint/test, GORM, GitHub, logs, docs; respuesta al humano; stack) | [docs/AGENT_RULES.md](./docs/AGENT_RULES.md) |
 
 **Obligaciones y respuesta al humano:** lista y detalle en [docs/AGENT_RULES.md](./docs/AGENT_RULES.md) (incluye qué hacer si no abres otro doc).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,61 +1,39 @@
 # Architecture — Cloudflax API (Backend)
 
-Documentación de la estructura, patrones y flujo de datos del backend.
+Estructura, patrones y flujo de datos del backend.
 
----
+## Stack
 
-## 1. Stack Tecnológico
+Go (feature-driven), Fiber v3, GORM + PostgreSQL; tests unitarios e integración (PostgreSQL/SQLite).
 
-- **Lenguaje**: Go (Estructura feature-driven).
-- **Framework**: Fiber v3.
-- **ORM**: GORM con PostgreSQL.
-- **Testing**: Unitarios y de integración con PostgreSQL/SQLite.
+## Directorios (`internal/`)
 
----
+- **`bootstrap/`**: Config, servidor, arranque.
+- **`{feature}/`**: `handler`, `service`, `repository`, `model`, `dto`, `routes`; opcional `validator` u helpers.
+- **`shared/`**: `database` (conexión, migraciones), `middleware`, `pagination`, `filtering`, `errors`, `validator`, `verificationnotify` (Lambda correo verificación), utilidades.
 
-## 2. Estructura de Directorios (Feature-driven)
+No todo feature necesita todos los archivos; lo mínimo suele ser `handler`, `repository`, `model`, `routes`.
 
-Cada funcionalidad vive en su propia carpeta dentro de `internal/`:
+## Capas
 
-- **`internal/bootstrap/`**: Configuración, servidor y arranque de la app.
-- **`internal/{feature}/`**: Puede contener `handler.go`, `service.go`, `repository.go`, `model.go`, `dto.go`, `routes.go` y opcionalmente `validator.go` u otros helpers específicos del recurso.
-- **`internal/shared/`**: Código común: `database` (conexión y migraciones), `middleware`, `pagination`, `filtering`, `errors`, `validator`, `verificationnotify` (invocación Lambda para correo de verificación) y otras utilidades compartidas.
+**Flujo:** `Request → Middleware → Handler → Service → Repository → DB`.
 
-No todos los features requieren todos estos archivos; un recurso simple puede usar solo `handler.go`, `repository.go`, `model.go` y `routes.go`.
+| Capa | Rol |
+|------|-----|
+| **Handler** | HTTP (Fiber): parseo y respuestas. Sin negocio ni DB directa; delega al Service. |
+| **Service** | Negocio y orquestación. Sin Fiber ni status HTTP; modelos y errores de dominio. |
+| **Repository** | GORM. Sin respuestas HTTP. |
+| **Validación** | DTOs / validadores antes del Service. |
 
----
+## Errores y middleware
 
-## 3. Patrones y Capas del Sistema
+Service/Repository devuelven errores de dominio (`ErrNotFound`, etc.); el Handler mapea a HTTP y JSON. Solo el Handler conoce transporte.
 
-- **Flujo de Datos**: `Request → Middleware → Handler → Service → Repository → DB`.
-- **Responsabilidades**:
-  - **Handler**: Solo HTTP (Fiber); parseo de requests y formateo de respuestas.
-  - **Service**: Lógica de negocio y orquestación; independiente de HTTP.
-  - **Repository**: Abstracción de acceso a datos (GORM).
-- **Validación**: Uso de DTOs y lógica de validación previa al Service.
-- **Reglas de dependencia entre capas**:
-  - **Handler**: No debe contener lógica de negocio ni acceder directamente a la base de datos; siempre delega en el Service.
-  - **Service**: No debe depender de HTTP (ni Fiber ni códigos de estado); trabaja con modelos de dominio y errores de dominio.
-  - **Repository**: No debe construir respuestas HTTP; solo se encarga del acceso a datos y de devolver errores de DB o de dominio.
+**Orden:** Logger → Request ID → Recovery → CORS → Auth (JWT). Logger (método, path, status, duración); Request ID (`X-Request-ID`); Recovery (panic → 500); CORS; Auth en rutas protegidas.
 
----
+## Desarrollo
 
-## 4. Manejo de Errores y Seguridad
-
-- **Errores**: Service/Repository devuelven errores de dominio (por ejemplo `ErrNotFound`, `ErrDuplicateEmail`); el Handler captura estos errores, los mapea a códigos HTTP coherentes y formatea la respuesta JSON.
-- **Restricción**: Ni Service ni Repository deben crear respuestas HTTP ni depender de Fiber; solo el Handler conoce detalles de transporte.
-- **Middleware Stack**: Logger → Request ID → Recovery → CORS → Auth (JWT).
-  - **Logger**: Registra método, path, status y duración de cada request.
-  - **Request ID**: Asigna y propaga un identificador (`X-Request-ID`) para facilitar el tracing entre logs.
-  - **Recovery**: Captura `panic` y evita la caída del servidor, devolviendo un error 500 controlado.
-  - **CORS**: Configura los encabezados para permitir el consumo desde el frontend autorizado.
-  - **Auth**: Valida JWT y restringe el acceso a rutas protegidas según la configuración de autorización.
-
----
-
-## 5. Workflow del Desarrollador
-
-1. **Implementar**: Seguir el flujo de capas definido y registrar rutas en `bootstrap/server/routes.go`.
-2. **Migrar**: Registrar cambios de modelos en `database.RunMigrations()`.
-3. **Validar**: Ejecución obligatoria de `make lint` y `make test`.
-4. **Testear**: Añadir tests unitarios por capa (Handler, Service, Repository) y tests de integración con base de datos (PostgreSQL o SQLite in-memory), ubicando los archivos `*_test.go` junto al código del feature.
+1. Capas anteriores; rutas en `bootstrap/server/routes.go`.
+2. Migraciones: `database.RunMigrations()`.
+3. `make lint` y `make test`.
+4. `*_test.go` junto al feature (unit por capa; integración PostgreSQL o SQLite in-memory).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Architecture — Cloudflax API (Backend)
+# Architecture | Cloudflax - Backend
 
 Estructura, patrones y flujo de datos del backend.
 

--- a/AUTH_INTEGRATION.md
+++ b/AUTH_INTEGRATION.md
@@ -1,4 +1,4 @@
-# Auth Integration — Cloudflax API
+# Auth Integration | Cloudflax - Backend
 
 Documento de referencia para integrar autenticación entre el frontend Next.js y este backend Go/Fiber.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-# Convenciones — Cloudflax API
+# Convenciones | Cloudflax - Backend
 
 Naming, carpetas, errores, handler/repository/service, DTOs, tests, estilo, docs de módulo, JSON y status HTTP.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,190 +1,67 @@
-# Convenciones de código — Cloudflax API
+# Convenciones — Cloudflax API
 
-Reglas para mantener consistencia. En este archivo van:
-
-- **Naming** — Cómo nombrar funciones, variables, archivos y recursos.
-- **Estructura de carpetas** — Organización, archivos estándar por módulo y registro en bootstrap.
-- **Errores de dominio** — Sentinel errors por módulo y mapeo a respuestas HTTP.
-- **Handler, Repository, Service** — Flujo del handler, patrones de repository/service, DTOs y constructores.
-- **Tests** — Setup de handler tests, decodificación de errores y casos a cubrir.
-- **Estilo de código** — Formato, imports, comentarios y buenas prácticas de sintaxis.
-- **Documentación de módulos** — Comentario de paquete y README por feature.
-- **Formato de API** — Respuestas JSON y códigos de estado por operación.
-
----
+Naming, carpetas, errores, handler/repository/service, DTOs, tests, estilo, docs de módulo, JSON y status HTTP.
 
 ## Nombres CRUD
 
-**Todas las acciones CRUD usan el mismo patrón en todos los features y en todas las capas:**
+Patrón `{Action}{Resource}` en handler, service, repository. **Resource** singular (`User`, `Country`). **Action:** `List`, `Get`, `Create`, `Update`, `Delete` (ej. `ListUser`, `GetCountry`, `DeleteOrder`).
 
-```
-{Action}{Resource}
-```
+## Estructura
 
-- **Resource** siempre en singular: `User`, `Country`, `Order`
-- **Action** de CRUD: `List`, `Get`, `Create`, `Update`, `Delete`
+- **Features:** `internal/{recurso}/` — singular, lowercase.
+- **Shared:** `internal/shared/{módulo}/`.
+- **Archivos:** `handler.go`, `service.go`, `repository.go`, `routes.go`, `dto.go`, `errors.go`, `model.go` según uso.
 
-| Acción | Ejemplo User | Ejemplo Country | Ejemplo Order |
-|--------|--------------|-----------------|---------------|
-| Listar | `ListUser` | `ListCountry` | `ListOrder` |
-| Obtener uno | `GetUser` | `GetCountry` | `GetOrder` |
-| Crear | `CreateUser` | `CreateCountry` | `CreateOrder` |
-| Actualizar | `UpdateUser` | `UpdateCountry` | `UpdateOrder` |
-| Eliminar | `DeleteUser` | `DeleteCountry` | `DeleteOrder` |
-
-**Aplica en:** `handler.go`, `service.go`, `repository.go` y cualquier archivo del feature.
-
----
-
-## Estructura de carpetas
-
-- **Features:** `internal/{recurso}/` — nombre en singular, lowercase (ej: `user`, `product`).
-- **Shared:** `internal/shared/{módulo}/` — código reutilizable entre features.
-- **Archivos:** Nombres en singular, lowercase, con sufijo por tipo (`handler.go`, `service.go`, `repository.go`).
-
-### Archivos estándar por módulo
-
-Cada módulo en `internal/{recurso}/` debe incluir al menos los archivos que use según responsabilidad:
-
-| Archivo | Uso |
+| Archivo | Rol |
 |---------|-----|
-| `model.go` | Modelo de dominio (GORM), tabla, métodos del modelo |
-| `repository.go` | Acceso a datos: `NewRepository(db)`, Get/Create/Update/Delete |
-| `service.go` | Lógica de negocio: `NewService(repository)`, mismos nombres CRUD que handler |
-| `handler.go` | HTTP: bind, validación, llamada al service, respuesta con `runtimeerror` |
-| `routes.go` | Función `Routes(router, handler, authMiddleware)` que monta los endpoints |
-| `dto.go` | Request/Response DTOs (ej. `CreateUserRequest`, `UpdateMeRequest`) con tags `json` y `validate` |
-| `errors.go` | Errores sentinel del dominio (ej. `ErrNotFound`, `ErrDuplicateEmail`) para que service/repository los devuelvan y el handler los mapee a códigos HTTP |
+| `model.go` | Dominio GORM |
+| `repository.go` | `NewRepository(db)`, CRUD; traducir `gorm.ErrRecordNotFound` → errores del paquete; `fmt.Errorf("op: %w", err)` para el resto |
+| `service.go` | `NewService(repo)`, mismos nombres CRUD; validar UUIDs; `ErrNotFound` si formato inválido; deps opcionales por interfaz + `if dep != nil` o `WithX()` |
+| `handler.go` | Bind, `validator.Validate`, service, `runtimeerror` |
+| `routes.go` | `Routes(router, handler, authMiddleware)` |
+| `dto.go` | `Create/Update{Resource}Request`, tags `json`/`validate`, punteros en updates opcionales |
+| `errors.go` | `var ErrX = fmt.Errorf(...)`; repo/service los devuelven; handler mapea con `errors.Is`/`errors.As` |
 
-Tests: `model_test.go` cuando el modelo tenga lógica a probar; `handler_test.go` con casos de éxito y de error. Opcionalmente tests de service o repository si la lógica lo justifica.
+Tests: `handler_test.go` (éxito + errores); `model_test.go` si hay lógica. **Bootstrap:** `internal/bootstrap/server/routes.go` → repo → service → handler → `{recurso}.Routes(...)`.
 
-Registro del módulo: en `internal/bootstrap/server/routes.go` crear repository → service (con opciones si aplica) → handler y llamar `{recurso}.Routes(app, handler, authMiddleware)`.
+## Errores HTTP
 
----
+Handler: `runtimeerror.Respond` / `RespondWithDetails`; códigos de recurso en `runtimeerror` (ej. `CodeUserNotFound`). Validación: helper tipo `toErrorDetails(validator.ValidationErrors)`. Inesperados: `slog` + `CodeInternalServerError`.
 
-## Errores de dominio y mapeo HTTP
+## Flujo handler
 
-- **Por módulo:** Definir en `errors.go` errores sentinel con `var ErrX = fmt.Errorf("...")` (ej. `ErrNotFound`, `ErrDuplicateEmail`). El **repository** y el **service** devuelven estos errores.
-- **Handler:** Mapear con `errors.Is(err, ErrNotFound)` (o `errors.As` para validación) y responder con `runtimeerror.Respond` / `runtimeerror.RespondWithDetails` usando los códigos definidos en `internal/shared/runtimeerror/runtimeerror.go`. Para validación, usar un helper privado tipo `toErrorDetails(validator.ValidationErrors)` que devuelva `[]runtimeError.ErrorDetail`.
-- **Códigos por recurso:** Los códigos específicos del recurso (ej. `CodeUserNotFound`, `CodeEmailAlreadyExists`) se definen en el paquete `runtimeerror`; el handler los usa al responder. Errores inesperados se loguean con `slog` y se responde con `CodeInternalServerError`.
+Auth (`requestctx.UserOnly` si aplica) → `ctx.Bind().Body(&req)` → `validator.Validate` → service → `errors.Is`/`errors.As` → JSON éxito `{"data": ...}` o 201/204 según operación.
 
----
+## DTOs / constructores
 
-## Flujo del handler
+`NewRepository(db)`, `NewService(repository)`, `NewHandler(service)`. Opcionales en service vía métodos que devuelven `*Service`.
 
-En cada endpoint: (1) extraer contexto de auth si aplica (`requestctx.UserOnly`), (2) bind del body con `ctx.Bind().Body(&req)`, (3) validar con `validator.Validate(req)` y en caso de error usar `RespondWithDetails` si hay detalles por campo, (4) llamar al service, (5) según el error devuelto (`errors.Is`/`errors.As`) responder con el status y código adecuados, (6) en éxito devolver `ctx.JSON(fiber.Map{"data": ...})` o `ctx.Status(201).JSON(...)` / `204` según la operación.
+## Tests handler
 
----
+Parámetro **`test *testing.T`** (no `t`). `Setup{Resource}HandlerTest(test)` → `database.InitForTesting()`, migraciones, repo → service → handler. `DecodeErrorResponse(test, body)` → `ErrorResponse` y `errorResponse.Error.Code`. Por endpoint: al menos un éxito y errores (401, 404, 422, 409, …) según aplique.
 
-## Repository y Service
+## Estilo
 
-- **Repository:** Traducir `gorm.ErrRecordNotFound` a los errores del paquete (ej. `ErrNotFound`). Envolver demás errores con `fmt.Errorf("operación: %w", err)`. No devolver errores de GORM crudos al service.
-- **Service:** Validar identificadores (ej. UUID con `uuid.Parse`) antes de llamar al repository; si el formato es inválido, devolver el mismo error que “no encontrado” (ej. `ErrNotFound`) para no revelar información. Dependencias externas (ej. revocador de tokens) inyectadas por **interfaz** y opcionales: comprobar `if service.dependency != nil` antes de usarlas; se pueden exponer con métodos tipo `WithTokenRevoker(tr) *Service` para mantener el constructor simple.
+Imports: std → third → internal, líneas en blanco. Alias camelCase para paquetes de una palabra confusa (ej. `runtimeError "…/runtimeerror"`). camelCase / PascalCase según exportación. **Código y comentarios en inglés.**
 
----
+Nombres: `userRepository` no `userRepo`; `repository`, `service`, `handler` en vars; excepciones: `err`, `ctx`, `id`, `req`/`resp`. Receivers descriptivos si hay ambigüedad.
 
-## DTOs y constructores
+## Docs módulo
 
-- **DTOs:** Nombres `Create{Resource}Request`, `Update{Resource}Request` (o `UpdateMeRequest` cuando aplique). Usar tags `json` y `validate`; en updates usar punteros para campos opcionales.
-- **Constructores:** `NewRepository(db *gorm.DB)`, `NewService(repository *Repository)`, `NewHandler(service *Service)`. Dependencias opcionales del service mediante métodos que devuelven `*Service` (builder style) para no complicar la firma del constructor.
+1. Comentario antes de `package`: `// Package user provides ...` (godoc).
+2. `README.md` en el feature: modelo, errores, HTTP, notas técnicas.
 
----
+## JSON
 
-## Tests de handler
+Éxito: `{"data": {...}, "message": "opcional"}`. Error: `error` con `code`, `message`, `status`, `trace_id`; validación añade `details[]` (`field`, `message`). Paginación: `meta` (`page`, `limit`, `total`). Helpers en `runtimeerror`.
 
-- **Parámetro de test:** En todas las funciones de test y helpers de test usar siempre `test *testing.T` (no `t *testing.T`). Ejemplo: `func SetupUserHandlerTest(test *testing.T) *Handler`, `func TestGetMe(test *testing.T)`.
-- **Setup:** Un helper `Setup{Resource}HandlerTest(test *testing.T)` que inicialice DB para tests (`database.InitForTesting()`), ejecute migraciones del modelo del módulo, cree repository → service → handler y devuelva el handler.
-- **Errores:** Helper `DecodeErrorResponse(test, body)` que decodifique el body en `runtimeError.ErrorResponse` para afirmar `errorResponse.Error.Code`.
-- **Casos:** Por endpoint, incluir al menos un test de éxito y tests por tipo de error (401, 404, 422, 409, etc.) según aplique.
+## Status
 
----
-
-## Estilo de código
-
-- **Imports:** Ordenar: estándar → terceros → internal. Agrupar con líneas en blanco.
-- **Alias de import:** Para paquetes cuyo nombre es una sola palabra en minúsculas que se lee como compuesta (ej. `runtimeerror`), usar alias en camelCase para mejorar legibilidad: `runtimeError "github.com/cloudflax/api.cloudflax/internal/shared/runtimeerror"`.
-- **Variables:** camelCase. Constantes y tipos exportados: PascalCase.
-- **Comentarios:** Siempre en inglés. Todo el código fuente debe estar íntegramente en inglés.
-
-### Nombres descriptivos (Clean Code)
-
-Evitar abreviaciones y nombres cortos que obligan al lector a “traducir” mentalmente. Preferir nombres que revelen la intención.
-
-- **No abreviar:** Preferir `userRepository`, `userService`, `userHandler` en lugar de `userRepo`, `userSvc`, `userHnd`.
-- **En parámetros y variables:** Usar nombres completos como `repository`, `service`, `handler`, `user`, `request`, `response`.
-- **Excepciones ampliamente conocidas:** `err` (error), `ctx` (context), `id`, `req`/`resp` en contexto HTTP — son convenciones estándar y legibles.
-- **Receivers:** Go acepta receivers de 1–2 letras; usar nombres descriptivos cuando mejoren la claridad (ej. `repository` o `svc` en lugar de `r` si hay varios receivers).
-
----
-
-## Documentación de módulos
-
-Cada módulo en `internal/{recurso}/` debe documentarse de dos formas:
-
-1. **Comentario de paquete (godoc):** En al menos un archivo `.go` del paquete, incluir un comentario inmediatamente antes de `package ...` que empiece por `Package <nombre>`. Es el texto que muestra `go doc` y pkg.go.dev. Ejemplo:
-   ```go
-   // Package user provides user identity management: profile CRUD, password
-   // hashing, soft delete, and session revocation.
-   package user
-   ```
-
-2. **README.md:** En la carpeta del módulo, un `README.md` con arquitectura del feature, modelo de datos (tablas/campos), diccionario de errores y códigos HTTP, y consideraciones técnicas (middlewares, validaciones, integraciones). Sirve como documentación para el equipo y onboarding.
-
-Los comentarios de tipos y funciones exportados siguen las reglas de **Estilo de código** (en inglés).
-
----
-
-## Formato de respuesta JSON
-
-**Éxito:**
-```json
-{
-  "data": { ... },
-  "message": "opcional"
-}
-```
-
-**Error (único):**
-```json
-{
-  "error": {
-    "code": "USER_NOT_FOUND",
-    "message": "user not found",
-    "status": 404,
-    "trace_id": "abc-123"
-  }
-}
-```
-
-**Error (múltiples campos — validación):**
-```json
-{
-  "error": {
-    "code": "VALIDATION_ERROR",
-    "message": "validation failed",
-    "status": 422,
-    "trace_id": "abc-123",
-    "details": [
-      { "field": "email", "message": "must be a valid email address" },
-      { "field": "password", "message": "must be at least 8 characters" }
-    ]
-  }
-}
-```
-
-Los códigos de error se definen en `internal/shared/runtimeerror/runtimeerror.go`. Los helpers `runtimeerror.Respond` y `runtimeerror.RespondWithDetails` construyen siempre esta estructura.
-
-Para listas paginadas, incluir `meta` con `page`, `limit`, `total`.
-
----
-
-## Status codes por operación
-
-| Operación | Éxito | Errores frecuentes |
-|-----------|-------|---------------------|
-| List | 200 | 400 (query inválida) |
-| Get by ID | 200 | 404 (no encontrado) |
-| Create | 201 | 400 (validación), 409 (duplicado) |
-| Update | 200 | 400 (validación), 404 (no encontrado) |
-| Delete | 200 o 204 | 404 (no encontrado) |
-| Login | 200 | 401 (credenciales inválidas) |
+| Operación | OK | Errores típicos |
+|-----------|-----|-----------------|
+| List | 200 | 400 |
+| Get | 200 | 404 |
+| Create | 201 | 400, 409 |
+| Update | 200 | 400, 404 |
+| Delete | 200 o 204 | 404 |
+| Login | 200 | 401 |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,4 +1,4 @@
-# Skills — Cloudflax API
+# Skills | Cloudflax - Backend
 
 Capacidades y conocimientos esperados para trabajar en este proyecto.
 

--- a/docs/AGENT_RULES.md
+++ b/docs/AGENT_RULES.md
@@ -10,7 +10,7 @@
 
 **Logs:** `slog` estructurado; nunca contraseñas, tokens ni PII.
 
-**Comentarios Go:** [`.cursor/rules/go-bilingual-comments.mdc`](../.cursor/rules/go-bilingual-comments.mdc).
+**Comentarios Go:** [.cursor/rules/go-bilingual-comments.mdc](../.cursor/rules/go-bilingual-comments.mdc).
 
 **Código (siempre):** inglés en identificadores y errores expuestos por la API; encadenar con `fmt.Errorf("…: %w", err)`; secretos solo vía env. Paginación y códigos HTTP: [CONVENTIONS.md](../CONVENTIONS.md).
 

--- a/docs/AGENT_RULES.md
+++ b/docs/AGENT_RULES.md
@@ -1,0 +1,23 @@
+# Reglas del agente | Cloudflax Backend
+
+Normas que aplican a quien implementa en este repo (Cursor u otro agente). El resumen enlaza desde [AGENTS.md](../AGENTS.md).
+
+## Obligaciones
+
+1. **Calidad antes de cerrar**: ejecuta `make lint` y `make test` antes de considerar el trabajo terminado.
+2. **Modelos GORM**: si cambias o añades un modelo, incluye su tipo en `database.RunMigrations(...)` en `cmd/api/main.go` (AutoMigrate vía `internal/shared/database`). Flujo: [ARCHITECTURE.md](../ARCHITECTURE.md).
+3. **GitHub**: sigue [GITHUB_WORKFLOW.md](./GITHUB_WORKFLOW.md). No hagas `push` ni abras PR salvo petición explícita. Commits en inglés, Conventional Commits, con `Refs` / `Closes` cuando aplique (detalle allí).
+4. **Logs**: usa `slog` estructurado; no registres contraseñas, tokens ni PII.
+5. **Código nuevo**: documenta según [`.cursor/rules/go-bilingual-comments.mdc`](../.cursor/rules/go-bilingual-comments.mdc).
+
+## Si no consultas otro documento
+
+Mantén el **código** en inglés (identificadores, mensajes de error expuestos por la API, etc.). Encadena errores con `fmt.Errorf("...: %w", err)`. Secretos solo vía variables de entorno. Listados paginados y códigos HTTP: [CONVENTIONS.md](../CONVENTIONS.md).
+
+## Respuesta al humano
+
+Redacta en **español**, de forma concisa. Indica explícitamente si el cambio afecta **`.env`** (u otra configuración por entorno) o si exige **migración** de base de datos.
+
+## Stack (recordatorio)
+
+Go 1.25, Fiber v3, GORM, PostgreSQL, `slog`. Detalle: [ARCHITECTURE.md](../ARCHITECTURE.md).

--- a/docs/AGENT_RULES.md
+++ b/docs/AGENT_RULES.md
@@ -1,23 +1,19 @@
 # Reglas del agente | Cloudflax Backend
 
-Normas que aplican a quien implementa en este repo (Cursor u otro agente). El resumen enlaza desde [AGENTS.md](../AGENTS.md).
+[AGENTS.md](../AGENTS.md) apunta aquí para obligaciones; abre otros docs solo si la tarea lo exige.
 
-## Obligaciones
+**Antes de cerrar:** `make lint` y `make test`.
 
-1. **Calidad antes de cerrar**: ejecuta `make lint` y `make test` antes de considerar el trabajo terminado.
-2. **Modelos GORM**: si cambias o añades un modelo, incluye su tipo en `database.RunMigrations(...)` en `cmd/api/main.go` (AutoMigrate vía `internal/shared/database`). Flujo: [ARCHITECTURE.md](../ARCHITECTURE.md).
-3. **GitHub**: sigue [GITHUB_WORKFLOW.md](./GITHUB_WORKFLOW.md). No hagas `push` ni abras PR salvo petición explícita. Commits en inglés, Conventional Commits, con `Refs` / `Closes` cuando aplique (detalle allí).
-4. **Logs**: usa `slog` estructurado; no registres contraseñas, tokens ni PII.
-5. **Código nuevo**: documenta según [`.cursor/rules/go-bilingual-comments.mdc`](../.cursor/rules/go-bilingual-comments.mdc).
+**GORM:** modelo nuevo o modificado → registrar el tipo en `database.RunMigrations(...)` (`cmd/api/main.go`). Detalle: [ARCHITECTURE.md](../ARCHITECTURE.md).
 
-## Si no consultas otro documento
+**GitHub:** [GITHUB_WORKFLOW.md](./GITHUB_WORKFLOW.md). Sin `push` ni PR salvo petición explícita. Commits en inglés, Conventional Commits; `Refs` / `Closes` cuando toque.
 
-Mantén el **código** en inglés (identificadores, mensajes de error expuestos por la API, etc.). Encadena errores con `fmt.Errorf("...: %w", err)`. Secretos solo vía variables de entorno. Listados paginados y códigos HTTP: [CONVENTIONS.md](../CONVENTIONS.md).
+**Logs:** `slog` estructurado; nunca contraseñas, tokens ni PII.
 
-## Respuesta al humano
+**Comentarios Go:** [`.cursor/rules/go-bilingual-comments.mdc`](../.cursor/rules/go-bilingual-comments.mdc).
 
-Redacta en **español**, de forma concisa. Indica explícitamente si el cambio afecta **`.env`** (u otra configuración por entorno) o si exige **migración** de base de datos.
+**Código (siempre):** inglés en identificadores y errores expuestos por la API; encadenar con `fmt.Errorf("…: %w", err)`; secretos solo vía env. Paginación y códigos HTTP: [CONVENTIONS.md](../CONVENTIONS.md).
 
-## Stack (recordatorio)
+**Respuesta al humano:** español, conciso. Indicar si el cambio afecta **`.env`** (u otra config por entorno) o exige **migración** de base de datos.
 
-Go 1.25, Fiber v3, GORM, PostgreSQL, `slog`. Detalle: [ARCHITECTURE.md](../ARCHITECTURE.md).
+**Stack:** Go 1.25, Fiber v3, GORM, PostgreSQL, `slog` — [ARCHITECTURE.md](../ARCHITECTURE.md).

--- a/docs/AGENT_RULES.md
+++ b/docs/AGENT_RULES.md
@@ -1,4 +1,4 @@
-# Reglas del agente | Cloudflax Backend
+# Agent Rules | Cloudflax - Backend
 
 [AGENTS.md](../AGENTS.md) apunta aquí para obligaciones; abre otros docs solo si la tarea lo exige.
 

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,0 +1,114 @@
+# GitHub: flujo y trazabilidad (`cloudflax/api.cloudflax`)
+
+Este documento define **qué hacer en orden** cuando el trabajo debe quedar enlazado a GitHub (issues, proyecto, ramas, commits). Sirve para humanos y para agentes (IA).
+
+**Regla previa:** no abras issue, rama ni PR **sin indicación del usuario**. Calidad de código (`make lint`, `make test`, GORM, etc.): [AGENT_RULES.md](./AGENT_RULES.md).
+
+---
+
+## 1. Modelo de ramas (referencia)
+
+| Rama / prefijo | Rol | En este repo |
+|----------------|-----|--------------|
+| `develop` | Integración habitual | Base de `feature/…` y **destino del PR** en trabajo normal. |
+| `main` | Estable / despliegue | Los features **no** apuntan aquí; PR va a `develop`. Hotfixes según acuerdo del equipo. |
+| `feature/<ID>-<slug>` | Tarea acotada al issue | `<ID>` = número del issue en GitHub. |
+| `release/<versión>` | Preparación de versión (opcional) | Política de equipo; suele mezclar en `main` y `develop`. |
+| `hotfix/<ID>-<slug>` | Urgencia sobre producción | Desde `main`; PR típico a `main` y **reintegrar en `develop`**. |
+
+---
+
+## 2. Decisión con el usuario (antes de tocar GitHub)
+
+El trabajo en GitHub es una **tubería** de piezas opcionales, en este orden lógico: **issue/project → rama → commits → PR** (y **estado en el tablero** al cerrar el ciclo). No ejecutes una fase si el usuario no la incluyó en el alcance de la sesión.
+
+### 2.1 Prompt copiable (checklist en el chat)
+
+Pedí al usuario que **pegue este bloque** en el mensaje y marque con `[x]` lo que aplica (en Cursor y en muchos visores de Markdown podés alternar la casilla con un clic). Lo no marcado se interpreta como **fuera de alcance** salvo que aclare otra cosa.
+
+```markdown
+**Alcance GitHub para esta tarea** (marcá con [x]):
+
+- [ ] **Issue + project**: crear o actualizar issue en `@api.cloudflax` y campos del tablero (Fase 3).
+- [ ] **Rama**: crear/publicar `feature/<ID>-<slug>` desde `develop` (Fase 4). Si no marcás esto, trabajo en la rama actual.
+- [ ] **Commits**: dejar cambios commiteados con Conventional Commits y `Refs`/`Closes` (Fase 5).
+- [ ] **PR**: push y abrir o actualizar PR hacia la base acordada (Fase 6).
+- [ ] **Tablero al cerrar**: ajustar `Status` del item cuando corresponda (Fase 7).
+
+Contexto breve (opcional): …
+```
+
+Si el usuario no usa la checklist, **preguntá en una sola franja** qué marca de la lista anterior necesita; no asumas trazabilidad completa.
+
+### 2.2 De la checklist a las fases
+
+| Qué está marcado | Fases (en orden) | Notas |
+|------------------|------------------|-------|
+| Issue + Rama + Commits + PR (+ tablero) | 3 → 4 → 5 → 6 → 7 | “Trazabilidad completa” típica. |
+| Rama + Commits + PR (+ tablero si aplica) | 4 → 5 → 6 → (7) | Issue ya existe o no se pide en esta sesión. |
+| Commits + PR | 5 → 6 | Ya estás en la rama correcta; no abras rama nueva. |
+| Solo PR | 6 | `push` solo si hace falta; no reescribas historia remota sin orden explícita. |
+| Solo issue / project | 3 | No crees rama hasta nueva orden. |
+| Issue + Rama (sin commits todavía) | 3 → 4 | Dejá Fase 5 para cuando haya cambios listos. |
+| Ya hay rama ligada al issue (`feature/…`, `hotfix/…`) y solo sigue el trabajo | 5 → 6 → (7) | No abras issue ni rama nuevas; alineá con lo marcado en la checklist. |
+
+**Regla:** si algo no está marcado, **no** hagas esa acción en GitHub (misma línea que la regla previa del documento y [AGENT_RULES.md](./AGENT_RULES.md) para `push`/PR).
+
+---
+
+## 3. Crear el issue y ubicarlo en el project
+
+1. **Issue** en el repo `cloudflax/api.cloudflax`, en el project **`@api.cloudflax`** (nombre exacto).  
+   Comando típico: `gh issue create -R cloudflax/api.cloudflax -p "@api.cloudflax"`.  
+   **Cuerpo en inglés:** objetivos y criterios de aceptación.
+2. **Asignación y etiquetas:** si el CLI lo permite, `--assignee cloudflax` y `--label …`; si hace falta otro assignee, aplícalo.
+3. **Tablero (sin campos vacíos obligatorios):** `Status`, `Priority`, `Size` y `Estimate` siempre con valor. **Start/Target date** solo con criterio o acuerdo; si no aplican, indícalo en el cuerpo del issue (no inventes fechas).
+
+**Checklist mínimo al dar por creada la pieza en GitHub:** issue en inglés y asignado · labels adecuados · en el project: Status, Priority, Size, Estimate · item enlazado al issue.
+
+---
+
+## 4. Crear la rama (solo si el usuario pidió rama + trazabilidad)
+
+1. Actualiza **`develop`** localmente.
+2. Crea **`feature/<ID_ISSUE>-<slug-kebab>`** desde **`develop`**. El `#ID` debe existir antes en GitHub.  
+   Puedes usar `gh issue develop` si enlaza o crea la rama con base correcta; si la base no es `develop`, créala a mano desde `develop`.
+3. Publica la rama remota y mantenla alineada con el issue/project.
+
+---
+
+## 5. Mientras trabajas: commits
+
+- **Idioma:** mensajes en **inglés**; [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, …).
+- **Enlace al issue:** antes de commitear, **lee el nombre de la rama** para obtener el `#ID` (ej. `feature/3-agents-md-hub` → `#3`). En el **cuerpo o pie** del mensaje usa `Refs #ID` o `Closes #ID` según si el commit cierra el issue o solo lo referencia.
+- **Historial:** sin `git commit --amend` ni reescritura de historial remoto **salvo** petición explícita del usuario.
+
+---
+
+## 6. Push y pull request
+
+- **`git push` y apertura de PR:** solo si el usuario lo pide **explícitamente** o hay acuerdo en la sesión (misma regla que en [AGENT_RULES.md](./AGENT_RULES.md)).
+- **Base del PR:** **`develop`** para features. **`main`** solo para hotfix (u otra política que el equipo deje por escrito).
+- **Descripción del PR:** incluye `Closes #ID` o `Refs #ID` según corresponda.
+
+---
+
+## 7. Estado en el project durante y después del review
+
+- **Status** debe reflejar la realidad. Valores habituales (orden típico): **Backlog** → **Ready** → **In progress** → **In review** → **Done**.
+- **In review:** con PR abierto (p. ej. hacia `develop`).
+- **Done:** cuando el código está mergeado en la rama de integración acordada o liberado según política del equipo.
+
+---
+
+## Apéndice: edición avanzada del project con `gh`
+
+1. `gh project list --owner cloudflax`
+2. `gh project field-list <n> --owner cloudflax`
+3. Obtener `item-id`: `gh project item-list`
+
+Edición: `gh project item-edit --project-id … --id <item-id> --field-id …` con `--single-select-option-id …`, `--number …`, `--date YYYY-MM-DD` o `--clear`. Para el issue: `gh issue edit <n> --add-assignee cloudflax --add-label "<label>"`.
+
+### Permisos
+
+Si fallan permisos o faltan scopes (`project`, `read:project`), pide al usuario `gh auth refresh` (u otra autenticación adecuada) antes de reintentar.


### PR DESCRIPTION
## Summary
- Add `docs/AGENT_RULES.md` and link from `AGENTS.md`.
- Add/expand `docs/GITHUB_WORKFLOW.md` with user checklist and phase mapping.

## Traceability
Closes #6

## Note
The repository default branch is `main` (no `develop` remote branch yet). Re-target the PR base to `develop` if the team adds it for git-flow.

Made with [Cursor](https://cursor.com)